### PR TITLE
docs: game should tap to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or include the following line in your HTML file:
 
 ## Usage
 
-Initialize the Rune SDK and and start your gameplay.
+Initialize the Rune SDK when initializing your game. The game can show animations to entice the player, but should wait on a tap from the player to start the actual gameplay as the game may be preloaded.
 
 ```js
 Rune.init({

--- a/examples/bunny-twirl/index.js
+++ b/examples/bunny-twirl/index.js
@@ -36,7 +36,7 @@ function scoreText(score) {
   return `You've survived ${score} bunny twirls`
 }
 let score = 0
-const text = new PIXI.Text(scoreText(score), {
+const text = new PIXI.Text("Tap to start!", {
   fontFamily: "Arial",
   fontSize: 12,
   fill: "white",
@@ -47,31 +47,42 @@ text.position.y = -50
 text.anchor.set(0.5)
 container.addChild(text)
 
+// Keep track of whether to animate and if the player started playing
+let isAnimating = true
+let isPlaying = false
+
 // Listen for animate update
-let isRunning = true
 app.ticker.add((delta) => {
   // Skip if game is paused
-  if (!isRunning) return
+  if (!isAnimating) return
 
-  // Rotate container and increment score (approx. 6.28 radians per rotation)
+  // Rotate container
   container.rotation += 0.01 * delta
-  score = Math.ceil(container.rotation / 6.28)
-  text.text = scoreText(score)
+
+  // Increment score if user started playing (approx. 6.28 radians per rotation)
+  if (isPlaying) {
+    score = Math.floor(container.rotation / 6.28)
+    if (text.text !== scoreText(score)) text.text = scoreText(score)
+  }
 })
 
 // Setup functions for starting the game etc.
 function startGame() {
   container.rotation = 0
-  isRunning = true
+
+  // Make user tap screen to actually start playing
+  isAnimating = true
+  isPlaying = false
+  text.text = "Tap to start!"
 }
 function pauseGame() {
-  isRunning = false
+  isAnimating = false
 }
 function resumeGame() {
-  isRunning = true
+  isAnimating = true
 }
 function endGame() {
-  isRunning = false
+  isAnimating = false
   text.text = `You gave up after ${score} twirls!`
   Rune.gameOver({ score })
 }
@@ -79,7 +90,12 @@ function endGame() {
 // End game on click / tap (i.e. player couldn't handle more twirls)
 for (const eventType of ["click", "touchstart"]) {
   document.body.addEventListener(eventType, function () {
-    endGame()
+    if (!isPlaying) {
+      // First tap should start gameplay
+      isPlaying = true
+    } else {
+      endGame()
+    }
   })
 }
 


### PR DESCRIPTION
Specify that game should wait on tap before starting gameplay as it may be preloaded in the background.

**Updated example game**
![image](https://user-images.githubusercontent.com/23178145/136105322-c0660e56-ce2d-4db9-bcb0-219a982b7d2a.png)
