### PR TITLE
docs: no audio before startGame()

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This simulates what the SDK will do based on player actions when your game is ru
 For the Rune leaderboard logic to work correctly, your game's score should:
 
 - be an integer
-- be 0 or higher (i.e. no negative values)
+- be between 0 and 1 billion (i.e. no negative or extremely high values)
 - treat higher scores as better
 
 This is the case by default for most games.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ For the Rune leaderboard logic to work correctly, your game's score should:
 
 This is the case by default for most games.
 
+## Audio
+
+Your game can have soundtracks and sound effects. However, your game should not play any audio before the `startGame` function is called.
+
 ## Help
 
 If you're having trouble, please feel free to file an issue in our [GitHub issue tracker](https://github.com/rune/rune-games-sdk/issues).


### PR DESCRIPTION
This prevent issues such as audio starting to play at unexpected moments due to game preloading.