### PR TITLE
build: only publish dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "typescript": "^4.4.3"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
Trivial change to only publish dist/ (and LICENSE and README.md and package.json, which are always included).