### PR TITLE
feat: get score function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,16 @@ export const Rune: RuneExport = {
   _pauseGame: () => {
     throw new Error("Rune._pauseGame() called before Rune.init()")
   },
+const validateScore = (score: number) => {
+  if (typeof score !== "number") {
+    throw new Error(`Score is not a number. Received: ${typeof score}`)
+  }
+  if (score < 0 || score > Math.pow(10, 9)) {
+    throw new Error(`Score is not between 0 and 1000000000. Received: ${score}`)
+  }
+  if (!Number.isInteger(score)) {
+    throw new Error(`Score is not an integer. Received: ${score}`)
+  }
 }
 
 // Create mock events to support development

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -106,6 +106,33 @@ describe("sdk", function () {
     expect(packageJson.version).toBe(version)
   })
 
+  test("SCORE event should include score from game's getScore()", async function () {
+    // Init with score function
+    let gameScore = 0
+    const getScore = () => {
+      return gameScore
+    }
+    Rune.init({
+      startGame: () => {},
+      pauseGame: () => {},
+      resumeGame: () => {},
+      getScore: getScore,
+    })
+
+    // Override postRuneEvent to extract score
+    let eventScore: number | undefined
+    globalThis.postRuneEvent = (event) => {
+      if (event.type === "SCORE") {
+        eventScore = event.score
+      }
+    }
+
+    // Mock game updating its local score and extract using _getScore
+    gameScore = 100
+    Rune._getScore()
+    expect(eventScore).toEqual(gameScore)
+  })
+
   test("allow replacing functions through code injection", async function () {
     let gameFinished = false
 


### PR DESCRIPTION
Needed to get the score when swiping on games etc. As part of this, I've removed the need to pass `score` to `Rune.gameOver()`.

I considered generalizing to a `getProgress` function that passes `score` as one property of an object to allow extending easily, but I'd rather keep it simple for now and then extend as needed.

`npm run build` and `npm run test` both run successfully.