### PR TITLE
example: make sure score is always postive

### DIFF
--- a/examples/bunny-twirl/index.html
+++ b/examples/bunny-twirl/index.html
@@ -9,6 +9,6 @@
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
-    <script src="index.js" type="module"></script>
+    <script src="index.js"></script>
   </body>
 </html>

--- a/examples/bunny-twirl/index.js
+++ b/examples/bunny-twirl/index.js
@@ -83,7 +83,7 @@ app.ticker.add((delta) => {
 
   // Increment score if user started playing
   if (isPlaying) {
-    score = Math.floor(container.rotation / (Math.PI * 2))
+    score = Math.abs(Math.floor(container.rotation / (Math.PI * 2)))
     if (text.text !== scoreText(score)) text.text = scoreText(score)
   }
 })


### PR DESCRIPTION
Fix negative score: with challengeNumber example Bunny Twirl game can rotate clockwise and anti-clockwise now and this caused that the score was negative half of time.