### PR TITLE
refactor: internal types at bottom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,13 +135,13 @@ const RuneLib = {
   },
 }
 
-// Global namespace properties needed to communicating with the Rune app
+// Global namespace properties needed for communicating with Rune
 declare global {
   var postRuneEvent: ((event: RuneGameEvent) => void) | undefined
   var _runeChallengeNumber: number | undefined
 }
 
-// "Events" sent to the Rune app to e.g. communicate that the game is over
+// "Events" sent to Rune to e.g. communicate that the game is over
 export type RuneGameEvent =
     | { type: "INIT"; version: string }
     | { type: "GAME_OVER"; score: number, challengeNumber: number }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,23 +2,12 @@
 The SDK interface for games to interact with Rune.
 */
 
-declare global {
-  var postRuneEvent: ((event: RuneGameEvent) => void) | undefined
-  var _runeChallengeNumber: number | undefined
-}
-
 interface InitInput {
   startGame: () => void
   resumeGame: () => void
   pauseGame: () => void
   getScore: () => number
 }
-
-export type RuneGameEvent =
-  | { type: "INIT"; version: string }
-  | { type: "GAME_OVER"; score: number, challengeNumber: number }
-  | { type: "ERR"; errMsg: string }
-  | { type: "SCORE"; score: number, challengeNumber: number }
 
 export interface RuneExport {
   // External properties and functions
@@ -145,3 +134,16 @@ const RuneLib = {
     }
   },
 }
+
+// Global namespace properties needed to communicating with the Rune app
+declare global {
+  var postRuneEvent: ((event: RuneGameEvent) => void) | undefined
+  var _runeChallengeNumber: number | undefined
+}
+
+// "Events" sent to the Rune app to e.g. communicate that the game is over
+export type RuneGameEvent =
+    | { type: "INIT"; version: string }
+    | { type: "GAME_OVER"; score: number, challengeNumber: number }
+    | { type: "ERR"; errMsg: string }
+    | { type: "SCORE"; score: number, challengeNumber: number }


### PR DESCRIPTION
Minor refactoring that moves the internal types to the bottom of the file. This makes it easier for any new game dev to read the file as they'll only see relevant info for them in the beginning (`InitInput` and `RuneExport`).

Also added comments to explain why we need `declare global` and what these events are for.

