### PR TITLE
build: add eslint global window

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     require: "readonly",
     setTimeout: "readonly",
     globalThis: "readonly",
+    window: "readonly",
   },
 
   overrides: [{


### PR DESCRIPTION
Needed to avoid errors when reading `browser.js`.