### PR TITLE
docs: load SDK early

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tiny SDK for making your HTML5 game run inside [Rune](https://play.google.com/st
 
 ## Install
 
-Include the following line at the top of your `index.html` file:
+Include the following line in your `index.html` file before loading any other JS scripts:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@2.1/dist/browser.min.js"></script>


### PR DESCRIPTION
Updating docs to support https://github.com/rune/rune-games-sdk/pull/65.