### PR TITLE
feat: add gamePlayUuid to machine context

### DIFF
--- a/src/internal/setupMessageBridge.ts
+++ b/src/internal/setupMessageBridge.ts
@@ -34,7 +34,7 @@ export function messageEventHandler(stateMachineService: StateMachineService) {
       case "playGame":
         return stateMachineService.send("onAppPlay", { gamePlayUuid: command.gamePlayUuid })
       case "_resumeGame":
-        return stateMachineService.send("onAppPlay", { gamePlayUuid: 'UNKNOWN' })
+        return stateMachineService.send("onAppPlay", { gamePlayUuid: "UNKNOWN" })
       case "_startGame":
         return stateMachineService.send("onAppStart (legacy)")
       case "setForceMuteStatus":

--- a/src/internal/setupMessageBridge.ts
+++ b/src/internal/setupMessageBridge.ts
@@ -30,10 +30,11 @@ export function messageEventHandler(stateMachineService: StateMachineService) {
       case "_requestScore":
         return stateMachineService.send("onAppRequestScore")
       case "restartGame":
-        return stateMachineService.send("onAppRestart")
+        return stateMachineService.send("onAppRestart", { gamePlayUuid: command.gamePlayUuid })
       case "playGame":
+        return stateMachineService.send("onAppPlay", { gamePlayUuid: command.gamePlayUuid })
       case "_resumeGame":
-        return stateMachineService.send("onAppPlay")
+        return stateMachineService.send("onAppPlay", { gamePlayUuid: 'UNKNOWN' })
       case "_startGame":
         return stateMachineService.send("onAppStart (legacy)")
       case "setForceMuteStatus":

--- a/src/internal/stateMachine.ts
+++ b/src/internal/stateMachine.ts
@@ -170,6 +170,7 @@ export function createStateMachine(challengeNumber: number) {
           const { resumeGame, startGame, legacyGameStarted } = context
           startGame && !legacyGameStarted ? startGame() : resumeGame()
 
+          // TODO: Remove this checks after removing onAppStart (legacy)
           if (event.type === "onAppPlay") {
             const gamePlayUuid = event.gamePlayUuid
 
@@ -188,6 +189,7 @@ export function createStateMachine(challengeNumber: number) {
           const { restartGame, startGame } = context
           startGame ? startGame() : restartGame()
 
+          // TODO: Remove this checks after removing onAppStart (legacy)
           if (event.type === "onAppPlay" || event.type === "onAppRestart") {
             return {
               ...context,

--- a/src/internal/stateMachine.ts
+++ b/src/internal/stateMachine.ts
@@ -35,7 +35,7 @@ export function createStateMachine(challengeNumber: number) {
       },
 
       context: {
-        gamePlayUuid: 'UNSET', // Game play uuid only makes sense while playing
+        gamePlayUuid: "UNSET", // Game play uuid only makes sense while playing
         rng: randomNumberGenerator(challengeNumber),
         restartGame: () => {
           throw new Error("restartGame is not initialized!")
@@ -170,7 +170,7 @@ export function createStateMachine(challengeNumber: number) {
           const { resumeGame, startGame, legacyGameStarted } = context
           startGame && !legacyGameStarted ? startGame() : resumeGame()
 
-          if (event.type === 'onAppPlay') {
+          if (event.type === "onAppPlay") {
             const gamePlayUuid = event.gamePlayUuid
 
             return {
@@ -188,7 +188,7 @@ export function createStateMachine(challengeNumber: number) {
           const { restartGame, startGame } = context
           startGame ? startGame() : restartGame()
 
-          if (event.type === 'onAppPlay' || event.type === 'onAppRestart') {
+          if (event.type === "onAppPlay" || event.type === "onAppRestart") {
             return {
               ...context,
               gamePlayUuid: event.gamePlayUuid

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,10 @@ declare global {
 // "Events" sent to Rune to e.g. communicate that the game is over
 export type RuneGameEvent =
   | { type: "INIT"; version: string }
-  | { type: "GAME_OVER"; score: number; challengeNumber: number }
-  | { type: "ERR"; errMsg: string }
-  | { type: "WARNING"; msg: string }
+  | { type: "GAME_OVER"; gamePlayUuid: string; score: number; challengeNumber: number }
+  | { type: "SCORE"; gamePlayUuid: string; score: number; challengeNumber: number }
+  | { type: "ERR"; gamePlayUuid: string; errMsg: string }
+  | { type: "WARNING"; gamePlayUuid: string; msg: string }
   | {
       type: "WINDOW_ERR"
       err: {
@@ -41,7 +42,6 @@ export type RuneGameEvent =
         colno: number
       }
     }
-  | { type: "SCORE"; score: number; challengeNumber: number }
   | { type: "BROWSER_INITIAL_OVERLAY_CLICKED" }
   | { type: "BROWSER_IFRAME_LOADED" }
 
@@ -51,5 +51,6 @@ export type LegacyRuneGameCommand = {
 }
 
 export type RuneAppCommand =
-  | { type: "playGame" | "pauseGame" | "restartGame" | "requestScore" }
+  | { type: "pauseGame" | "requestScore" }
+  | { type: "playGame" | "restartGame"; gamePlayUuid: string }
   | { type: "setForceMuteStatus"; muted: boolean }

--- a/test/messageBridge.test.ts
+++ b/test/messageBridge.test.ts
@@ -72,7 +72,7 @@ describe("Message Bridge", () => {
       initRune(Rune, { resumeGame })
 
       const messageEvent = new MessageEvent("message", {
-        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: '1' }),
+        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: "1" }),
       })
 
       globalThis.dispatchEvent(messageEvent)
@@ -91,7 +91,7 @@ describe("Message Bridge", () => {
       initRune(Rune, { resumeGame })
 
       const messageEvent = new MessageEvent("message", {
-        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: '1' }),
+        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: "1" }),
       })
 
       document.dispatchEvent(messageEvent)

--- a/test/messageBridge.test.ts
+++ b/test/messageBridge.test.ts
@@ -72,7 +72,7 @@ describe("Message Bridge", () => {
       initRune(Rune, { resumeGame })
 
       const messageEvent = new MessageEvent("message", {
-        data: stringifyRuneGameCommand({ type: "playGame" }),
+        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: '1' }),
       })
 
       globalThis.dispatchEvent(messageEvent)
@@ -91,7 +91,7 @@ describe("Message Bridge", () => {
       initRune(Rune, { resumeGame })
 
       const messageEvent = new MessageEvent("message", {
-        data: stringifyRuneGameCommand({ type: "playGame" }),
+        data: stringifyRuneGameCommand({ type: "playGame", gamePlayUuid: '1' }),
       })
 
       document.dispatchEvent(messageEvent)

--- a/test/rng.test.ts
+++ b/test/rng.test.ts
@@ -37,7 +37,7 @@ describe("rng", () => {
 
     initRune(Rune)
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame" })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
 
     const randomArray2 = [...Array(7)].map(() =>
       Math.round(Rune.deterministicRandom() * 10)
@@ -53,9 +53,9 @@ describe("rng", () => {
     )
 
     initRune(Rune)
-    sendRuneAppCommand(stateMachineService, { type: "playGame" })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
     Rune.gameOver()
-    sendRuneAppCommand(stateMachineService, { type: "playGame" })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '2' })
 
     // See that random numbers are identical
     const randomArray2 = [...Array(7)].map(() =>
@@ -73,8 +73,8 @@ describe("rng", () => {
 
     initRune(Rune)
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame" })
-    sendRuneAppCommand(stateMachineService, { type: "restartGame" })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
+    sendRuneAppCommand(stateMachineService, { type: "restartGame", gamePlayUuid: '2' })
 
     const randomArray2 = [...Array(7)].map(() =>
       Math.round(Rune.deterministicRandom() * 10)

--- a/test/rng.test.ts
+++ b/test/rng.test.ts
@@ -37,7 +37,7 @@ describe("rng", () => {
 
     initRune(Rune)
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
 
     const randomArray2 = [...Array(7)].map(() =>
       Math.round(Rune.deterministicRandom() * 10)
@@ -53,9 +53,9 @@ describe("rng", () => {
     )
 
     initRune(Rune)
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
     Rune.gameOver()
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '2' })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "2" })
 
     // See that random numbers are identical
     const randomArray2 = [...Array(7)].map(() =>
@@ -73,8 +73,8 @@ describe("rng", () => {
 
     initRune(Rune)
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
-    sendRuneAppCommand(stateMachineService, { type: "restartGame", gamePlayUuid: '2' })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+    sendRuneAppCommand(stateMachineService, { type: "restartGame", gamePlayUuid: "2" })
 
     const randomArray2 = [...Array(7)].map(() =>
       Math.round(Rune.deterministicRandom() * 10)

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -96,7 +96,7 @@ describe("sdk", function () {
     initRune(Rune, { getScore })
 
     // Override postRuneEvent to extract score
-    let scoreEvent: Extract<RuneGameEvent, { type: 'SCORE' }> | undefined
+    let scoreEvent: Extract<RuneGameEvent, { type: "SCORE" }> | undefined
 
     runePostMessageHandler((event) => {
       if (event.type === "SCORE") {
@@ -109,7 +109,7 @@ describe("sdk", function () {
     sendRuneAppCommand(stateMachineService, { type: "requestScore" })
     expect(scoreEvent?.score).toEqual(gameScore)
     expect(scoreEvent?.challengeNumber).toEqual(customChallengeNumber)
-    expect(scoreEvent?.gamePlayUuid).toEqual('UNSET')
+    expect(scoreEvent?.gamePlayUuid).toEqual("UNSET")
   })
 
   test("should support legacy _requestScore command", async function () {
@@ -125,7 +125,7 @@ describe("sdk", function () {
     initRune(Rune, { getScore })
 
     // Override postRuneEvent to extract score
-    let scoreEvent: Extract<RuneGameEvent, { type: 'SCORE' }> | undefined
+    let scoreEvent: Extract<RuneGameEvent, { type: "SCORE" }> | undefined
 
     runePostMessageHandler((event) => {
       if (event.type === "SCORE") {
@@ -138,7 +138,7 @@ describe("sdk", function () {
     sendRuneAppCommand(stateMachineService, { type: "_requestScore" })
     expect(scoreEvent?.score).toEqual(gameScore)
     expect(scoreEvent?.challengeNumber).toEqual(customChallengeNumber)
-    expect(scoreEvent?.gamePlayUuid).toEqual('UNSET')
+    expect(scoreEvent?.gamePlayUuid).toEqual("UNSET")
   })
 
   test("GAME_OVER event should include score from game's getScore() and challenge number", async function () {
@@ -154,7 +154,7 @@ describe("sdk", function () {
     initRune(Rune, { getScore })
 
     // Override postRuneEvent to extract score and challenge number
-    let gameOverEvent: Extract<RuneGameEvent, { type: 'GAME_OVER' }> | undefined
+    let gameOverEvent: Extract<RuneGameEvent, { type: "GAME_OVER" }> | undefined
 
     runePostMessageHandler((event) => {
       if (event.type === "GAME_OVER") {
@@ -164,11 +164,11 @@ describe("sdk", function () {
 
     // Mock game updating its local score and extract using gameOver
     gameScore = 100
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
     Rune.gameOver()
     expect(gameOverEvent?.score).toEqual(gameScore)
     expect(gameOverEvent?.challengeNumber).toEqual(customChallengeNumber)
-    expect(gameOverEvent?.gamePlayUuid).toEqual('1')
+    expect(gameOverEvent?.gamePlayUuid).toEqual("1")
   })
 
   describe("error state", () => {
@@ -238,7 +238,7 @@ describe("sdk", function () {
       })
 
       initRune(Rune)
-      sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
+      sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
       Rune.gameOver()
       Rune.gameOver()
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -179,65 +179,68 @@ describe("sdk", function () {
     test("ERR event should be sent when init is called multiple times", () => {
       const { Rune } = getRuneSdk({ challengeNumber })
 
-      let error: string | null = null
+      let errEvent: Extract<RuneGameEvent, { type: "ERR" }> | undefined
 
       runePostMessageHandler((event) => {
         if (event.type === "ERR") {
-          error = event.errMsg
+          errEvent = event
         }
       })
 
       initRune(Rune)
       initRune(Rune)
 
-      expect(error).toEqual(
+      expect(errEvent?.errMsg).toEqual(
         "Fatal issue: Received onGameInit while in INIT.PAUSED"
       )
+      expect(errEvent?.gamePlayUuid).toEqual("UNSET")
     })
 
     test("ERR event should be sent when game over is without initialization", () => {
       const { Rune } = getRuneSdk({ challengeNumber })
 
-      let error: string | null = null
+      let errEvent: Extract<RuneGameEvent, { type: "ERR" }> | undefined
 
       runePostMessageHandler((event) => {
         if (event.type === "ERR") {
-          error = event.errMsg
+          errEvent = event
         }
       })
 
       Rune.gameOver()
 
-      expect(error).toEqual("Fatal issue: Received onGameOver while in LOADING")
+      expect(errEvent?.errMsg).toEqual("Fatal issue: Received onGameOver while in LOADING")
+      expect(errEvent?.gamePlayUuid).toEqual("UNSET")
     })
 
     test("ERR event should be sent when  game over is called during pause", () => {
       const { Rune } = getRuneSdk({ challengeNumber })
 
-      let error: string | null = null
+      let errEvent: Extract<RuneGameEvent, { type: "ERR" }> | undefined
 
       runePostMessageHandler((event) => {
         if (event.type === "ERR") {
-          error = event.errMsg
+          errEvent = event
         }
       })
 
       initRune(Rune)
       Rune.gameOver()
 
-      expect(error).toEqual(
+      expect(errEvent?.errMsg).toEqual(
         "Fatal issue: Received onGameOver while in INIT.PAUSED"
       )
+      expect(errEvent?.gamePlayUuid).toEqual("UNSET")
     })
 
     test("ERR event should be sent when game over is called multiple times in a row", () => {
       const { Rune, stateMachineService } = getRuneSdk({ challengeNumber })
 
-      let error: string | null = null
+      let errEvent: Extract<RuneGameEvent, { type: "ERR" }> | undefined
 
       runePostMessageHandler((event) => {
         if (event.type === "ERR") {
-          error = event.errMsg
+          errEvent = event
         }
       })
 
@@ -246,9 +249,10 @@ describe("sdk", function () {
       Rune.gameOver()
       Rune.gameOver()
 
-      expect(error).toEqual(
+      expect(errEvent?.errMsg).toEqual(
         "Fatal issue: Received onGameOver while in INIT.GAME_OVER"
       )
+      expect(errEvent?.gamePlayUuid).toEqual("1")
     })
   })
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -167,7 +167,7 @@ describe("sdk", function () {
 
     // Mock game updating its local score and extract using gameOver
     gameScore = 100
-    sendRuneAppCommand(stateMachineService, { type: "playGame" })
+    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
     Rune.gameOver()
     expect(eventScore).toEqual(gameScore)
     expect(eventChallengeNumber).toEqual(customChallengeNumber)
@@ -240,7 +240,7 @@ describe("sdk", function () {
       })
 
       initRune(Rune)
-      sendRuneAppCommand(stateMachineService, { type: "playGame" })
+      sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: '1' })
       Rune.gameOver()
       Rune.gameOver()
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -145,7 +145,7 @@ describe("sdk", function () {
     expect(scoreEvent?.gamePlayUuid).toEqual("2")
   })
 
-  test("GAME_OVER event should include score from game's getScore() and challenge number", async function () {
+  test("GAME_OVER event should include score from game's getScore(), game play uuid and challenge number", async function () {
     const customChallengeNumber = 123
     const { Rune, stateMachineService } = getRuneSdk({
       challengeNumber: customChallengeNumber,
@@ -213,7 +213,7 @@ describe("sdk", function () {
       expect(errEvent?.gamePlayUuid).toEqual("UNSET")
     })
 
-    test("ERR event should be sent when  game over is called during pause", () => {
+    test("ERR event should be sent when game over is called during pause", () => {
       const { Rune } = getRuneSdk({ challengeNumber })
 
       let errEvent: Extract<RuneGameEvent, { type: "ERR" }> | undefined

--- a/test/stateMachine.test.ts
+++ b/test/stateMachine.test.ts
@@ -74,34 +74,34 @@ beforeEach(async () => {
 describe("stateMachine", function () {
   test("User starts the game, clicks pause and clicks play again", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame" }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
       [{ type: "pauseGame" }, "pauseGame"],
-      [{ type: "playGame" }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: '2' }, "resumeGame"],
     ])
   })
 
   test("User starts the game, clicks restart", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame" }, "resumeGame"],
-      [{ type: "restartGame" }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
+      [{ type: "restartGame", gamePlayUuid: '2' }, "restartGame"],
     ])
   })
 
   test("User starts the game, loses it, and starts to play again", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame" }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
       ["SDK_GAME_OVER", "gameOverMessage"],
-      [{ type: "playGame" }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: '2' }, "restartGame"],
     ])
   })
 
   test("User starts the game, loses it, starts to play again, pauses, resumes", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame" }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
       ["SDK_GAME_OVER", "gameOverMessage"],
-      [{ type: "playGame" }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: '2' }, "restartGame"],
       [{ type: "pauseGame" }, "pauseGame"],
-      [{ type: "playGame" }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: '3' }, "resumeGame"],
     ])
   })
 
@@ -191,9 +191,9 @@ describe("stateMachine", function () {
     test("User starts the game, clicks pause and clicks play again", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
           [{ type: "pauseGame" }, "pauseGame"],
-          [{ type: "playGame" }, "resumeGame"],
+          [{ type: "playGame", gamePlayUuid: '2' }, "resumeGame"],
         ],
         true
       )
@@ -202,8 +202,8 @@ describe("stateMachine", function () {
     test("User starts the game, clicks restart", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame" }, "startGame"],
-          [{ type: "restartGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
+          [{ type: "restartGame", gamePlayUuid: '2' }, "startGame"],
         ],
         true
       )
@@ -212,9 +212,9 @@ describe("stateMachine", function () {
     test("User starts the game, loses it, and starts to play again", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
           ["SDK_GAME_OVER", "gameOverMessage"],
-          [{ type: "playGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '2' }, "startGame"],
         ],
         true
       )
@@ -223,11 +223,11 @@ describe("stateMachine", function () {
     test("User starts the game, loses it, starts to play again, pauses, resumes", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
           ["SDK_GAME_OVER", "gameOverMessage"],
-          [{ type: "playGame" }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: '2' }, "startGame"],
           [{ type: "pauseGame" }, "pauseGame"],
-          [{ type: "playGame" }, "resumeGame"],
+          [{ type: "playGame", gamePlayUuid: '3' }, "resumeGame"],
         ],
         true
       )

--- a/test/stateMachine.test.ts
+++ b/test/stateMachine.test.ts
@@ -74,34 +74,34 @@ beforeEach(async () => {
 describe("stateMachine", function () {
   test("User starts the game, clicks pause and clicks play again", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: "1" }, "resumeGame"],
       [{ type: "pauseGame" }, "pauseGame"],
-      [{ type: "playGame", gamePlayUuid: '2' }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: "2" }, "resumeGame"],
     ])
   })
 
   test("User starts the game, clicks restart", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
-      [{ type: "restartGame", gamePlayUuid: '2' }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: "1" }, "resumeGame"],
+      [{ type: "restartGame", gamePlayUuid: "2" }, "restartGame"],
     ])
   })
 
   test("User starts the game, loses it, and starts to play again", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: "1" }, "resumeGame"],
       ["SDK_GAME_OVER", "gameOverMessage"],
-      [{ type: "playGame", gamePlayUuid: '2' }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: "2" }, "restartGame"],
     ])
   })
 
   test("User starts the game, loses it, starts to play again, pauses, resumes", async function () {
     testStateMachineCallbacks([
-      [{ type: "playGame", gamePlayUuid: '1' }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: "1" }, "resumeGame"],
       ["SDK_GAME_OVER", "gameOverMessage"],
-      [{ type: "playGame", gamePlayUuid: '2' }, "restartGame"],
+      [{ type: "playGame", gamePlayUuid: "2" }, "restartGame"],
       [{ type: "pauseGame" }, "pauseGame"],
-      [{ type: "playGame", gamePlayUuid: '3' }, "resumeGame"],
+      [{ type: "playGame", gamePlayUuid: "3" }, "resumeGame"],
     ])
   })
 
@@ -191,9 +191,9 @@ describe("stateMachine", function () {
     test("User starts the game, clicks pause and clicks play again", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "1" }, "startGame"],
           [{ type: "pauseGame" }, "pauseGame"],
-          [{ type: "playGame", gamePlayUuid: '2' }, "resumeGame"],
+          [{ type: "playGame", gamePlayUuid: "2" }, "resumeGame"],
         ],
         true
       )
@@ -202,8 +202,8 @@ describe("stateMachine", function () {
     test("User starts the game, clicks restart", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
-          [{ type: "restartGame", gamePlayUuid: '2' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "1" }, "startGame"],
+          [{ type: "restartGame", gamePlayUuid: "2" }, "startGame"],
         ],
         true
       )
@@ -212,9 +212,9 @@ describe("stateMachine", function () {
     test("User starts the game, loses it, and starts to play again", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "1" }, "startGame"],
           ["SDK_GAME_OVER", "gameOverMessage"],
-          [{ type: "playGame", gamePlayUuid: '2' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "2" }, "startGame"],
         ],
         true
       )
@@ -223,11 +223,11 @@ describe("stateMachine", function () {
     test("User starts the game, loses it, starts to play again, pauses, resumes", async function () {
       testStateMachineCallbacks(
         [
-          [{ type: "playGame", gamePlayUuid: '1' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "1" }, "startGame"],
           ["SDK_GAME_OVER", "gameOverMessage"],
-          [{ type: "playGame", gamePlayUuid: '2' }, "startGame"],
+          [{ type: "playGame", gamePlayUuid: "2" }, "startGame"],
           [{ type: "pauseGame" }, "pauseGame"],
-          [{ type: "playGame", gamePlayUuid: '3' }, "resumeGame"],
+          [{ type: "playGame", gamePlayUuid: "3" }, "resumeGame"],
         ],
         true
       )


### PR DESCRIPTION
Add gamePlayUuid to machine context so that receiver of `RuneGameEvent` knows for which game play the event applies to:
* Initialise with `UNSET`
* Set `gamePlayUuid` when `playGame` or `restartGame` `RuneAppCommand` is received
* Send `gamePlayUuid` when `GAME_OVER`, `SCORE`, `ERR`, `WARNING` `RuneGameEvent` is triggered