### PR TITLE
docs: add quick start and improve organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 
 - #### pauseGame
   Rune will call this function when:
-  1. The player presses the pause button during gameplay.
+  1. The player presses the pause button while playing.
   
   Your game should instantly freeze all gameplay and wait until `resumeGame` is called.
 
 - #### restartGame
   Rune will call this function when:
   1. The player presses the restart button in the middle of a game.
-  2. The player has lost a game and choose to play it again.
+  2. The player has lost a game and chooses to play it again.
 
   Your game should reset all gameplay back to the experience as a completely new player, including resetting the score.
 
@@ -81,7 +81,7 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 
 - When the player loses or completes the game, call `Rune.gameOver()`.
 - Rune will check if it's a new high score and encourage the player to share your game or play again.
-- The game should freeze until `restartGame` is called.
+- Your game should freeze until `restartGame` is called and does not need to show any "game over" screen.
 
 ### Rune.getChallengeNumber (optional)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Rune.init({
 })
 ```
 
+The Rune SDK uses the functions you provide to `Rune.init()` to communicate with your game.
+
 - #### resumeGame
   `resumeGame` will be called in two scenarios:
   - When the player first decides to start your game by hitting play.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,11 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 
   For the Rune leaderboard logic to work correctly, your game's score should:
   - be an integer
-  - be between 0 and 1 billion (i.e. no negative or extremely high values)
+  - be between 0 and 1 billion
   - treat higher scores as better
 
 ### Rune.gameOver
-```js
-Rune.gameOver()
-```
+
 - When the user loses the game / dies / completes the game, call `Rune.gameOver()`.
 - Rune will automatically check if it's a new high score, display a confetti animation and encourage the user to share your game / restart and play again.
 - The game can freeze or be gently animating until `restartGame` is called by the SDK.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Adapting your HTML5 game to run on Rune is really simple.
 // Your game setup code...
 
 // Initialize the Rune SDK once your game is fully ready.
-// Rune will invoke these functions based on user actions in the app interface.
+// Rune will invoke these functions based on player actions in the app interface.
 Rune.init({
   resumeGame: myResumeGameFunction,
   pauseGame: myPauseGameFunction,
@@ -28,7 +28,7 @@ Rune.init({
   getScore: myGetScoreFunction
 })
 
-// When the user loses the game, inform the SDK
+// When the player loses the game, inform the SDK
 Rune.gameOver()
 ```
 
@@ -54,17 +54,17 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 - #### resumeGame
   `resumeGame` will be called in two scenarios:
   - When the player first decides to start your game by hitting play.
-  - If the user had paused the game at some point and subsequently presses play again.
+  - If the player had paused the game at some point and subsequently presses play again.
   
   Whenever it's called, start / resume the gameplay.
 
 - #### pauseGame
-  `pauseGame` will be called whenever the user presses the pause button during gameplay. It should instantly freeze all gameplay and wait until `resumeGame` is called.
+  `pauseGame` will be called whenever the player presses the pause button during gameplay. It should instantly freeze all gameplay and wait until `resumeGame` is called.
 
 - #### restartGame
   `restartGame` is called in two scenarios:
-  - In the middle of a game, if a user chooses to press the restart button.
-  - After a user has lost a game, when they choose to replay it again.
+  - In the middle of a game, if a player chooses to press the restart button.
+  - After a player has lost a game, when they choose to replay it again.
 
   Your game should reset all gameplay back to the experience as a completely new player, including resetting the score.
 
@@ -78,8 +78,8 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 
 ### Rune.gameOver
 
-- When the user loses the game / dies / completes the game, call `Rune.gameOver()`.
-- Rune will automatically check if it's a new high score, display a confetti animation and encourage the user to share your game / restart and play again.
+- When the player loses the game / dies / completes the game, call `Rune.gameOver()`.
+- Rune will automatically check if it's a new high score, display a confetti animation and encourage the player to share your game / restart and play again.
 - The game can freeze or be gently animating until `restartGame` is called by the SDK.
 
 ### Rune.getChallengeNumber (optional)

--- a/README.md
+++ b/README.md
@@ -52,26 +52,27 @@ Rune.init({
 The Rune SDK uses the functions you provide to `Rune.init()` to communicate with your game.
 
 - #### resumeGame
-  `resumeGame` will be called in two scenarios:
-  - When the player first decides to start your game by hitting play.
-  - If the player had paused the game at some point and subsequently presses play again.
+  Rune will call this function when:
+  1. The player first decides to start your game by hitting play.
+  2. The player had paused the game and subsequently presses play again.
   
-  Whenever it's called, start / resume the gameplay.
+  Your game should start / resume the gameplay.
 
 - #### pauseGame
-  `pauseGame` will be called whenever the player presses the pause button during gameplay. It should instantly freeze all gameplay and wait until `resumeGame` is called.
+  Rune will call this function when:
+  1. The player presses the pause button during gameplay.
+  
+  Your game should instantly freeze all gameplay and wait until `resumeGame` is called.
 
 - #### restartGame
-  `restartGame` is called in two scenarios:
-  - In the middle of a game, if a player chooses to press the restart button.
-  - After a player has lost a game, when they choose to replay it again.
+  Rune will call this function when:
+  1. The player presses the restart button in the middle of a game.
+  2. The player has lost a game and choose to play it again.
 
   Your game should reset all gameplay back to the experience as a completely new player, including resetting the score.
 
 - #### getScore
-  The Rune SDK may request your game's score at anytime by calling the `getScore` function. This function should return your game's score as a number.
-
-  For the Rune leaderboard logic to work correctly, your game's score should:
+  Rune may request your game's score at anytime by calling this function, which should return your game's score. For the Rune leaderboard logic to work correctly, your game's score should:
   - be an integer
   - be between 0 and 1 billion
   - treat higher scores as better

--- a/README.md
+++ b/README.md
@@ -78,10 +78,15 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
   - treat higher scores as better
 
 ### Rune.gameOver
+When the player loses or completes the game, call `Rune.gameOver()`.
 
-- When the player loses or completes the game, call `Rune.gameOver()`.
+```js
+Rune.gameOver()
+```
+
 - Rune will check if it's a new high score and encourage the player to share your game or play again.
-- Your game should freeze until `restartGame` is called and does not need to show any "game over" screen.
+- Your game should freeze until `restartGame` is called. 
+- Your game need not show a "game over" screen. Rune overlays a standardized high score interface to the user.
 
 ### Rune.getChallengeNumber (optional)
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The Rune SDK uses the functions you provide to `Rune.init()` to communicate with
 
 ### Rune.gameOver
 
-- When the player loses the game / dies / completes the game, call `Rune.gameOver()`.
-- Rune will automatically check if it's a new high score, display a confetti animation and encourage the player to share your game / restart and play again.
-- The game can freeze or be gently animating until `restartGame` is called by the SDK.
+- When the player loses or completes the game, call `Rune.gameOver()`.
+- Rune will check if it's a new high score and encourage the player to share your game or play again.
+- The game should freeze until `restartGame` is called.
 
 ### Rune.getChallengeNumber (optional)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rune.init({
 Rune.gameOver()
 ```
 
-That's all it takes to add your game to Rune!
+That's all it takes to integrate your game with Rune!
 
 ## API Details
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,33 @@ Include the following line in your `index.html` file before loading any other JS
 <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@2.2/dist/browser.min.js"></script>
 ```
 
-## Use
+## Quick Start
+Adapting your HTML5 game to run on Rune is really simple.
 
-Initialize the Rune SDK once your game is fully ready.
+```js
+
+// Your game setup code...
+
+// Initialize the Rune SDK once your game is fully ready.
+// Rune will invoke these functions based on user actions in the app interface.
+Rune.init({
+  resumeGame: myResumeGameFunction,
+  pauseGame: myPauseGameFunction,
+  restartGame: myRestartGameFunction,
+  getScore: myGetScoreFunction
+})
+
+// When the user loses the game, inform the SDK
+Rune.gameOver()
+```
+
+That's all it takes to add your game to Rune!
+
+## API Details
+
+
+### Rune.init
+The init function should be called after your game is fully ready. At this point, the game can show animations to entice the player, but should not start the actual gameplay as the game may be preloaded.
 
 ```js
 Rune.init({
@@ -25,19 +49,40 @@ Rune.init({
 })
 ```
 
-At this point, the game can show animations to entice the player, but should not start the actual gameplay as the game may be preloaded. When the player wants to start your game, Rune will call the provided `resumeGame` function to let your game know to start the gameplay.
+- #### resumeGame
+  `resumeGame` will be called in two scenarios:
+  - When the player first decides to start your game by hitting play.
+  - If the user had paused the game at some point and subsequently presses play again.
+  
+  Whenever it's called, start / resume the gameplay.
 
-Once the player loses the game, your game should call `Rune.gameOver()`. This tells Rune to show the "game over" screen. Your game should not show any "game over" screen and your game does not need to keep track of the user's highscore.
+- #### pauseGame
+  `pauseGame` will be called whenever the user presses the pause button during gameplay. It should instantly freeze all gameplay and wait until `resumeGame` is called.
 
-When the player is ready to play again, Rune will call the `restartGame` function. Your game should then reset all gameplay back to the experience as a completely new player, including resetting the score. The player is also able to restart the game manually, which will make Rune call the `restartGame` function.
+- #### restartGame
+  `restartGame` is called in two scenarios:
+  - In the middle of a game, if a user chooses to press the restart button.
+  - After a user has lost a game, when they choose to replay it again.
 
-The player may pause the game through the Rune interface. When this happens, the `pauseGame` function is called to let your game know to freeze all gameplay. Similarly, the `resumeGame` function should unfreeze all gameplay, leaving the player in the same state as before they paused the game.
+  Your game should reset all gameplay back to the experience as a completely new player, including resetting the score.
 
-The Rune SDK may request your game's score at anytime by calling the `getScore` function. This function should return your game's score as a number.
+- #### getScore
+  The Rune SDK may request your game's score at anytime by calling the `getScore` function. This function should return your game's score as a number.
 
-Take a look at our [example game](https://github.com/rune/rune-games-sdk/blob/staging/examples/bunny-twirl/index.js) for inspiration or dive into the [source code](https://github.com/rune/rune-games-sdk/blob/staging/src/index.ts).
+  For the Rune leaderboard logic to work correctly, your game's score should:
+  - be an integer
+  - be between 0 and 1 billion (i.e. no negative or extremely high values)
+  - treat higher scores as better
 
-## Challenge Number (optional)
+### Rune.gameOver
+```js
+Rune.gameOver()
+```
+- When the user loses the game / dies / completes the game, call `Rune.gameOver()`.
+- Rune will automatically check if it's a new high score, display a confetti animation and encourage the user to share your game / restart and play again.
+- The game can freeze or be gently animating until `restartGame` is called by the SDK.
+
+### Rune.getChallengeNumber (optional)
 
 Rune provides a challenge number through `Rune.getChallengeNumber()` that will increment every day starting from value 1. It's optional to use the challenge number, but we strongly encourage using it to keep your game entertaining and make everyone compete under the same conditions.
 
@@ -79,6 +124,9 @@ You should only use `Rune.deterministicRandom()` for your map generation and not
 
 For instance, for a racing game with 20 predefined maps you would use method (1) above. Alternatively, if the racing game randomly generates maps by placing turns and obstacles then you would use method (2). The high-level goal is just to make sure that your game is deterministic, i.e. the same challenge number always creates the same player experience.
 
+## Example Game
+Take a look at our [example game](https://github.com/rune/rune-games-sdk/blob/staging/examples/bunny-twirl/index.js) for inspiration or dive into the [source code](https://github.com/rune/rune-games-sdk/blob/staging/src/index.ts).
+
 ## Submission
 
 When your game is ready, please zip it as a folder containing `index.html` as the entry point of the game. The folder should contain all resources that are used by the game (css, js, images, soundtracks, helper libs, etc). In other words, please make sure that the game does not fetch any external resources from the Internet except for Rune Games SDK.
@@ -86,16 +134,6 @@ When your game is ready, please zip it as a folder containing `index.html` as th
 ## Debugging
 
 Use the [Rune CLI](https://github.com/rune/rune-games-cli) to test your game's integration with the SDK.
-
-## Score
-
-For the Rune leaderboard logic to work correctly, your game's score should:
-
-- be an integer
-- be between 0 and 1 billion (i.e. no negative or extremely high values)
-- treat higher scores as better
-
-This is the case by default for most games.
 
 ## Audio
 


### PR DESCRIPTION
- Tried to break down the paragraphs into bullet points
- Added a section for Rune.gameOver() — now the sections match the API and `Rune.gameOver()` is harder to miss.

I will do a separate PR for the challenge number section.
