### PR TITLE
feat: alternative way of getting the score

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,15 @@ export function getRuneSdk({ challengeNumber }: { challengeNumber: number }) {
   const Rune: RuneExport = {
     version: "2.2.3",
     init: (input) => {
+      if (input.getScore.canNotReturn) {
+        const originalGetScore = input.getScore
+
+        input.getScore = () => {
+          originalGetScore()
+          return originalGetScore.score
+        }
+      }
+
       validateInput(input)
 
       stateMachineService.send("onGameInit", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ The SDK interface for games to interact with Rune.
 import { RuneExport, InitInput } from "./types"
 import { createStateMachine } from "./internal/stateMachine"
 import { validateInput } from "./internal/validations"
+import { normalizeInitInput } from "./internal/normalizeInitInput"
 
 export function getRuneSdk({ challengeNumber }: { challengeNumber: number }) {
   const stateMachineService = createStateMachine(challengeNumber)
@@ -11,14 +12,7 @@ export function getRuneSdk({ challengeNumber }: { challengeNumber: number }) {
   const Rune: RuneExport = {
     version: "2.2.3",
     init: (input) => {
-      if (input?.getScore?.canNotReturn) {
-        const originalGetScore = input.getScore
-
-        input.getScore = () => {
-          originalGetScore()
-          return originalGetScore.score
-        }
-      }
+      normalizeInitInput(input)
 
       validateInput(input)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export function getRuneSdk({ challengeNumber }: { challengeNumber: number }) {
   const Rune: RuneExport = {
     version: "2.2.3",
     init: (input) => {
-      if (input.getScore.canNotReturn) {
+      if (input?.getScore?.canNotReturn) {
         const originalGetScore = input.getScore
 
         input.getScore = () => {

--- a/src/internal/normalizeInitInput.ts
+++ b/src/internal/normalizeInitInput.ts
@@ -1,0 +1,14 @@
+import { InitInput } from "../types"
+
+// Alternative way to provide the score in some non-JS environments, where
+// integration with JS does not allow to return values from callbacks.
+export function normalizeInitInput(input: InitInput) {
+  if (input?.getScore?.callbackReturnValueNotSupported) {
+    const originalGetScore = input.getScore
+
+    input.getScore = () => {
+      originalGetScore()
+      return originalGetScore.score
+    }
+  }
+}

--- a/src/internal/stateMachine.ts
+++ b/src/internal/stateMachine.ts
@@ -2,10 +2,10 @@ import { createMachine, interpret, assign } from "xstate"
 import { randomNumberGenerator } from "./rng"
 import { validateScore } from "./validations"
 import { postRuneEvent } from "./messageBridge"
-import { InitInput } from "../types"
+import { NormalizedInitInput } from "../types"
 
 export type Events =
-  | ({ type: "onGameInit" } & InitInput & {
+  | ({ type: "onGameInit" } & NormalizedInitInput & {
         version: string
       })
   | { type: "onGameOver" }
@@ -19,7 +19,7 @@ type Context = {
   gamePlayUuid: string
   rng: () => number
   legacyGameStarted: boolean
-} & InitInput
+} & NormalizedInitInput
 
 export type StateMachineService = ReturnType<typeof createStateMachine>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,10 @@ export interface InitInput {
   startGame?: () => void
 }
 
+export type NormalizedInitInput = Omit<InitInput, "getScore"> & {
+  getScore: () => number
+}
+
 export interface RuneExport {
   // External properties and functions
   version: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,16 @@ export interface InitInput {
   restartGame: () => void
   resumeGame: () => void
   pauseGame: () => void
-  getScore: () => number
+  getScore:
+    | {
+        (): number
+        canNotReturn?: false
+      }
+    | {
+        (): number
+        canNotReturn: true
+        score: number
+      }
   // deprecated
   startGame?: () => void
 }
@@ -29,8 +38,18 @@ declare global {
 // "Events" sent to Rune to e.g. communicate that the game is over
 export type RuneGameEvent =
   | { type: "INIT"; version: string }
-  | { type: "GAME_OVER"; gamePlayUuid: string; score: number; challengeNumber: number }
-  | { type: "SCORE"; gamePlayUuid: string; score: number; challengeNumber: number }
+  | {
+      type: "GAME_OVER"
+      gamePlayUuid: string
+      score: number
+      challengeNumber: number
+    }
+  | {
+      type: "SCORE"
+      gamePlayUuid: string
+      score: number
+      challengeNumber: number
+    }
   | { type: "ERR"; gamePlayUuid: string; errMsg: string }
   | { type: "WARNING"; gamePlayUuid: string; msg: string }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,11 @@ export interface InitInput {
   getScore:
     | {
         (): number
-        canNotReturn?: false
+        callbackReturnValueNotSupported?: false
       }
     | {
         (): void
-        canNotReturn: true
+        callbackReturnValueNotSupported: true
         score: number
       }
   // deprecated

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface InitInput {
         canNotReturn?: false
       }
     | {
-        (): number
+        (): void
         canNotReturn: true
         score: number
       }

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -67,10 +67,10 @@ describe("sdk", function () {
     function getScore() {
       getScore.score = score
     }
-    getScore.canNotReturn = true as const
+    getScore.callbackReturnValueNotSupported = true as const
 
     // this line is just to make typescript happy within the context of this test
-    getScore.score = score
+    getScore.score = 0
 
     initRune(Rune, { getScore })
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -62,11 +62,15 @@ describe("sdk", function () {
   test("alternative way of providing the score using reference on getScore", async () => {
     const { Rune, stateMachineService } = getRuneSdk({ challengeNumber })
 
+    let score: number = 0
+
     function getScore() {
-      getScore.score = 33
+      getScore.score = score
     }
     getScore.canNotReturn = true as const
-    getScore.score = 0
+
+    // this line is just to make typescript happy within the context of this test
+    getScore.score = score
 
     initRune(Rune, { getScore })
 
@@ -78,8 +82,8 @@ describe("sdk", function () {
       }
     })
 
+    score = 33
     sendRuneAppCommand(stateMachineService, { type: "requestScore" })
-
     expect(scoreEvent?.score).toEqual(33)
   })
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -59,6 +59,30 @@ describe("sdk", function () {
     ).toMatchInlineSnapshot(`"Score is not a number. Received: string"`)
   })
 
+  test("alternative way of providing the score using reference on getScore", async () => {
+    const { Rune, stateMachineService } = getRuneSdk({ challengeNumber })
+
+    function getScore() {
+      getScore.score = 33
+    }
+    getScore.canNotReturn = true as const
+    getScore.score = 0
+
+    initRune(Rune, { getScore })
+
+    let scoreEvent: Extract<RuneGameEvent, { type: "SCORE" }> | undefined
+
+    runePostMessageHandler((event) => {
+      if (event.type === "SCORE") {
+        scoreEvent = event
+      }
+    })
+
+    sendRuneAppCommand(stateMachineService, { type: "requestScore" })
+
+    expect(scoreEvent?.score).toEqual(33)
+  })
+
   test("exposed version should match npm version", async function () {
     const { Rune } = getRuneSdk({ challengeNumber })
     const packageJson = require("../package.json")
@@ -108,7 +132,10 @@ describe("sdk", function () {
       }
     })
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "playGame",
+      gamePlayUuid: "1",
+    })
     // Mock game updating its local score
     gameScore = 100
     sendRuneAppCommand(stateMachineService, { type: "requestScore" })
@@ -145,10 +172,16 @@ describe("sdk", function () {
       }
     })
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "playGame",
+      gamePlayUuid: "1",
+    })
     // Mock game updating its local score
     gameScore = 100
-    sendRuneAppCommand(stateMachineService, { type: "restartGame", gamePlayUuid: "2" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "restartGame",
+      gamePlayUuid: "2",
+    })
 
     // Score event should contain score achieved in the game
     expect(scoreEvent?.score).toEqual(100)
@@ -179,8 +212,14 @@ describe("sdk", function () {
     // Mock game updating its local score and extract using _requestScore
     gameScore = 100
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
-    sendRuneAppCommand(stateMachineService, { type: "restartGame", gamePlayUuid: "2" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "playGame",
+      gamePlayUuid: "1",
+    })
+    sendRuneAppCommand(stateMachineService, {
+      type: "restartGame",
+      gamePlayUuid: "2",
+    })
     sendRuneAppCommand(stateMachineService, { type: "_requestScore" })
     expect(scoreEvent?.score).toEqual(gameScore)
     expect(scoreEvent?.challengeNumber).toEqual(customChallengeNumber)
@@ -210,7 +249,10 @@ describe("sdk", function () {
 
     // Mock game updating its local score and extract using gameOver
     gameScore = 100
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "playGame",
+      gamePlayUuid: "1",
+    })
     Rune.gameOver()
     expect(gameOverEvent?.score).toEqual(gameScore)
     expect(gameOverEvent?.challengeNumber).toEqual(customChallengeNumber)
@@ -251,7 +293,9 @@ describe("sdk", function () {
 
       Rune.gameOver()
 
-      expect(errEvent?.errMsg).toEqual("Fatal issue: Received onGameOver while in LOADING")
+      expect(errEvent?.errMsg).toEqual(
+        "Fatal issue: Received onGameOver while in LOADING"
+      )
       expect(errEvent?.gamePlayUuid).toEqual("UNSET")
     })
 
@@ -287,7 +331,10 @@ describe("sdk", function () {
       })
 
       initRune(Rune)
-      sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+      sendRuneAppCommand(stateMachineService, {
+        type: "playGame",
+        gamePlayUuid: "1",
+      })
       Rune.gameOver()
       Rune.gameOver()
 
@@ -309,10 +356,15 @@ describe("sdk", function () {
       }
     })
 
-    sendRuneAppCommand(stateMachineService, { type: "playGame", gamePlayUuid: "1" })
+    sendRuneAppCommand(stateMachineService, {
+      type: "playGame",
+      gamePlayUuid: "1",
+    })
     sendRuneAppCommand(stateMachineService, { type: "pauseGame" })
     sendRuneAppCommand(stateMachineService, { type: "pauseGame" })
-    expect(warningEvent?.msg).toEqual("Received onAppPause while in INIT.PAUSED")
+    expect(warningEvent?.msg).toEqual(
+      "Received onAppPause while in INIT.PAUSED"
+    )
     expect(warningEvent?.gamePlayUuid).toEqual("1")
   })
 })


### PR DESCRIPTION
Added support for getting the score using a field on `getScore` function for environments where returning from a callback is not supported. 