### PR TITLE
chore: use rune sdk v3 in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "yarn workspaces run build",
     "lint": "eslint .",
     "test": "yarn workspaces run test",
-    "typecheck": "yarn workspaces run typecheck"
+    "typecheck": "yarn workspaces run typecheck",
+    "example-breakout": "rune start singleplayer/examples/breakout",
+    "example-bunny-twirl": "rune start singleplayer/examples/bunny-twirl",
+    "example-tic-tac-toe": "rune start multiplayer/examples/tic-tac-toe"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.45.0",

--- a/singleplayer/examples/breakout/index.html
+++ b/singleplayer/examples/breakout/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="width=device-width, user-scalable=no">
+    <meta name="viewport" content="width=device-width, user-scalable=no" />
     <title>Breakout</title>
-    <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@2.5.2/dist/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@3/singleplayer.js"></script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css"

--- a/singleplayer/examples/bunny-twirl/index.html
+++ b/singleplayer/examples/bunny-twirl/index.html
@@ -3,10 +3,10 @@
   <head>
     <title>Bunny Twirl</title>
     <link rel="icon" type="image/x-icon" href="favicon.png" />
-    <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@2.5.2/dist/browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@3/singleplayer.js"></script>
     <script src="pixi.min.js"></script>
     <script src="seedrandom.min.js"></script>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <script src="index.js"></script>

--- a/singleplayer/godot/README.md
+++ b/singleplayer/godot/README.md
@@ -10,7 +10,7 @@ Add the following code to "Head Include" in the "HTML" section of your HTML5
 export preset options:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@2.5.2/dist/browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@3/singleplayer.js"></script>
 ```
 
 <img src="https://i.gyazo.com/9e8b207f5340be67144cc5a56fa7426b.png" width="600">


### PR DESCRIPTION
As a bonus this adds an easy way to run the examples with yarn as well. 