### PR TITLE
feat: allow Math.random

### DIFF
--- a/docs/docs/multiplayer/logic-restrictions.md
+++ b/docs/docs/multiplayer/logic-restrictions.md
@@ -6,16 +6,18 @@ sidebar_position: 4
 
 When writing multiplayer games in Rune, the game state is distributed across all players and a Rune server. To make sure all players see the same thing there are some limitations on what kind of code you can write in the `logic.js` file (`client.js` is not affected).
 
-The primary aim is to ensure that the code is deterministic, meaning that if you run the code multiple times with the same input it will produce the same result. The main contributors to non-deterministic code in this context is use of other non-deterministic functions such as `Math.random()`/`Date.now()` and access of shared state such as counters and cache variables. **To avoid errors in production the Rune Multiplayer SDK will check your code** for the following unsafe patterns:
+The primary aim is to ensure that the code is deterministic, meaning that if you run the code multiple times with the same input it will produce the same result. The main contributors to non-deterministic code in this context is use of other non-deterministic functions such as `Date.now()` and access of shared state such as counters and cache variables. **To avoid errors in production the Rune Multiplayer SDK will check your code** for the following unsafe patterns:
 
 - **Mutation and assignment of variables outside of current function scope**. Since mutation of function arguments are allowed for ergonomic reasons, it's also not allowed to read non-local variables, just invoking functions/methods.
 - **`async`/`await` syntax** as the SDK requires logic to be synchronous.
 - **`try`/`catch` syntax** as this might interfere with Rune game control flow. Throwing is still allowed in case your program hits an irrecoverable error state.
-- **Use of non-deterministic runtime built-ins** such as `Math.random`, `Date`, `fetch` etc.
+- **Use of non-deterministic runtime built-ins** such as `Date`, `fetch` etc.
 - **Modules** such as `import/export` and `require` as the SDK requires your logic to be self-contained in a single file. If you want to share logic or split the file into multiple you may use a bundler like rollup to produce a single file from many.
 - **Non-serializable data types** such as `Set`, `Map`, `Promise` etc because the game state needs to be able to be represented as `JSON`.
 - **Regular expressions** because they are stateful.
 - **Use of `eval`** because it's potentially harmful and can be used to bypass above rules.
+
+A notable exception to this list is `Math.random()` which is ensured to be deterministic, see [Randomness](randomness.md) to read more about how this works.
 
 The [Rune CLI](cli.md) will warn you if your game logic uses unsafe code so don't worry!
 

--- a/docs/docs/multiplayer/randomness.md
+++ b/docs/docs/multiplayer/randomness.md
@@ -21,9 +21,9 @@ Rune solves this problem by implementing a deterministic pseudorandom number gen
 
 What's great about it is that the game can do optimistic updates which leads to a really fast game, and that cheating is hard as the player client only knows how to generate their own numbers and cannot know what the other players will get.
 
-## Great, but sounds complicated?
+## Things to keep in mind
 
-Yes, but not for your game! Rune solves this transparently and in the majority of cases **you can keep using `Math.random()`** as you would in any other game. There are some specific things to keep in mind:
+Rune solves this transparently and in the majority of cases **you can keep using `Math.random()`** as you would in any other game. There are some specific things to keep in mind however:
 
 ### Keep all shared state in `logic.js`
 
@@ -31,4 +31,7 @@ This isn't limited to randomness, but is especially important here, as only the 
 
 ### Shared random
 
-If your games needs deterministic shared randomness, meaning that the randomness is determined by the order an action is taken, regardless of who makes an action. This can be solved in different ways depending on the needs. One way is to use `Math.random()` in `setup()` to set a shared random state to be used in your own number generator, another is to generate all state that depends on randomness in `setup()`.
+If your games needs deterministic shared randomness, meaning that the randomness is determined by the order an action is taken, regardless of who makes an action. This can be solved in different ways depending on the needs:
+
+- Set a shared random state in `setup()` using `Math.random()` to be used in your own number generator.
+- Generate all state that depends on randomness in `setup()` such as the board in a collaborative minesweeper game.

--- a/docs/docs/multiplayer/randomness.md
+++ b/docs/docs/multiplayer/randomness.md
@@ -4,6 +4,12 @@ sidebar_position: 6
 
 # Randomness
 
+:::tip
+
+**TL;DR**: just use `Math.random()`.
+
+:::
+
 Most games involve some kind of randomness, for example to roll a die in the case of Yahtzee. However, randomness introduces some problems:
 
 - True randomness is inherently **not deterministic**, which is not compatible with Rune's distributed game state model.
@@ -13,11 +19,11 @@ Most games involve some kind of randomness, for example to roll a die in the cas
 
 Rune solves this problem by implementing a deterministic pseudorandom number generator. In simpler words this means the Rune server tells each player client to calculate random numbers. For every action the player takes, the server verifies that the random numbers being generated are in fact generated in the way the server told it to.
 
-What's great about it is that the game can do optimistic updates which leads to a really fast game, and that cheating is hard as the player client only knows how to generate their own numbers and cannot know what the other players will get. However, the main drawback with this is that in some cases a technically sophisticated player might be able to "peek" at their next die/card etc (also known as a lookahead attack).
+What's great about it is that the game can do optimistic updates which leads to a really fast game, and that cheating is hard as the player client only knows how to generate their own numbers and cannot know what the other players will get.
 
-## Great, but sounds complicated
+## Great, but sounds complicated?
 
-Yes, but not for your game! Rune solves this transparently and in the majority of cases **you can keep using `Math.random()`** as you would in any other game. There are some specific gotchas that is good to know about:
+Yes, but not for your game! Rune solves this transparently and in the majority of cases **you can keep using `Math.random()`** as you would in any other game. There are some specific things to keep in mind:
 
 ### Keep all shared state in `logic.js`
 

--- a/docs/docs/multiplayer/randomness.md
+++ b/docs/docs/multiplayer/randomness.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 6
+---
+
+# Randomness
+
+Most games involve some kind of randomness, for example to roll a die in the case of Yahtzee. However randomness introduces some problems:
+
+- True randomness is inherently **not deterministic**, which is not compatible with Rune's distributed game state model.
+- True randomness with optimistic updates places trust in the client, and therefore **opens up to cheating** for a technically sophisticated player.
+
+## Deterministic random
+
+Rune solve this problem by implementing a deterministic pseudorandom number generator. In simpler words this means the Rune server tells each player client to calculate random numbers. For every action the player takes, the server verifies that the random numbers being generated are in fact generated in the way the server told it to.
+
+What's great about it is that the game can do optimistic updates which leads to a really fast game, and that cheating is hard as the player client only knows how to generate their own numbers and cannot know what the other players will get. However, the main drawback with this is that in some cases a technically sophisticated player might be able to "peek" at their next die/card etc (also known as a lookahead attack).
+
+## Great, but sounds complicated
+
+Yes, but not for your game! Rune solves this transparently and in the majority of cases **you can keep using `Math.random()`** as you would in any other game. There are some specific gotchas that is good to know about:
+
+### Keep all shared state in `logic.js`
+
+This isn't limited to randomness, but is especially important here, as only the code called from within `Rune.initLogic()`/`logic.js` has the deterministic random. If you have some kind of initialization code that generates data for your game, make sure to do this in `setup()` so that all players see the same thing.
+
+### Shared random
+
+If your games needs a deterministic shared randomness, meaning that the randomness is determined by the order an action is taken, regardless of who makes an action. This can be solved in different ways depending on the needs. One way is to use `Math.random()` in `setup()` to set a shared random state to be used in your own number generator, another is to generate all state that depends on randomness in `setup()`.

--- a/docs/docs/multiplayer/randomness.md
+++ b/docs/docs/multiplayer/randomness.md
@@ -4,14 +4,14 @@ sidebar_position: 6
 
 # Randomness
 
-Most games involve some kind of randomness, for example to roll a die in the case of Yahtzee. However randomness introduces some problems:
+Most games involve some kind of randomness, for example to roll a die in the case of Yahtzee. However, randomness introduces some problems:
 
 - True randomness is inherently **not deterministic**, which is not compatible with Rune's distributed game state model.
 - True randomness with optimistic updates places trust in the client, and therefore **opens up to cheating** for a technically sophisticated player.
 
 ## Deterministic random
 
-Rune solve this problem by implementing a deterministic pseudorandom number generator. In simpler words this means the Rune server tells each player client to calculate random numbers. For every action the player takes, the server verifies that the random numbers being generated are in fact generated in the way the server told it to.
+Rune solves this problem by implementing a deterministic pseudorandom number generator. In simpler words this means the Rune server tells each player client to calculate random numbers. For every action the player takes, the server verifies that the random numbers being generated are in fact generated in the way the server told it to.
 
 What's great about it is that the game can do optimistic updates which leads to a really fast game, and that cheating is hard as the player client only knows how to generate their own numbers and cannot know what the other players will get. However, the main drawback with this is that in some cases a technically sophisticated player might be able to "peek" at their next die/card etc (also known as a lookahead attack).
 
@@ -25,4 +25,4 @@ This isn't limited to randomness, but is especially important here, as only the 
 
 ### Shared random
 
-If your games needs a deterministic shared randomness, meaning that the randomness is determined by the order an action is taken, regardless of who makes an action. This can be solved in different ways depending on the needs. One way is to use `Math.random()` in `setup()` to set a shared random state to be used in your own number generator, another is to generate all state that depends on randomness in `setup()`.
+If your games needs deterministic shared randomness, meaning that the randomness is determined by the order an action is taken, regardless of who makes an action. This can be solved in different ways depending on the needs. One way is to use `Math.random()` in `setup()` to set a shared random state to be used in your own number generator, another is to generate all state that depends on randomness in `setup()`.

--- a/docs/docs/multiplayer/supported-games.md
+++ b/docs/docs/multiplayer/supported-games.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # What Kinds of Games are Supported?
@@ -12,14 +12,14 @@ Any game that follows the [overall restrictions](multiplayer/syncing-game-state.
 - Chess, Connect Four, Mancala, Battleship, Checkers and other strategy games
 - Collaborative crosswords, Werewolf and other co-op games with simultaneous turns
 - 8 Ball Pool, Golf Around!, Football Tactics & Glory, and other turn-based sports games
+- Catan, Yahtzee, Monopoly and other strategy games with randomness
 
 There's a lot more games you can build, these are just some examples to give you an idea of what's possible!
 
 ## Examples of Supported Games in Upcoming Version
 
-Rune's exclusive alpha multiplayer SDK has some great new updates coming, including randomness and more!
+Rune's exclusive alpha multiplayer SDK has some great new updates coming!
 
-- Catan, Yahtzee, Monopoly and other strategy games with randomness
 - Pet Simulator, Viscera Cleanup Detail, The Game of Life, and other simulation games
 - Codenames, Guess Who, Music Quiz and other party games
 - Super Mario Bros, Unravel Two, Cuphead and other sidescrollers without live multiplayer interactions

--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -111,14 +111,18 @@ const logicConfig: ESLint.ConfigData = {
     "no-restricted-properties": [
       2,
       {
-        object: "Math",
-        property: "random",
-        message:
-          "Math.random() is not deterministic and may not be in logic.js.",
+        object: "Rune",
+        property: "init",
+        message: "Rune.init() is restricted to client-only code.",
       },
       {
         object: "Rune",
-        property: "init",
+        property: "initClient",
+        message: "Rune.init() is restricted to client-only code.",
+      },
+      {
+        object: "Rune",
+        property: "deterministicRandom",
         message: "Rune.init() is restricted to client-only code.",
       },
     ],

--- a/packages/eslint-plugin-rune/test/config/globals.spec.js
+++ b/packages/eslint-plugin-rune/test/config/globals.spec.js
@@ -14,6 +14,7 @@ test("globals", {
     "Math.sin()",
     "Math.pow()",
     "Math.log()",
+    "Math.random()",
     "123 * Math.PI",
     "const matematik = {}; Object.assign(matematik, { hest: 'snel' })",
     "isNaN(12)",
@@ -25,7 +26,8 @@ test("globals", {
   invalid: [
     ["Rune.init()", "restrictedObjectProperty"],
     ["Prune.initLogic()", "undef"],
-    ["Math.random()", "restrictedObjectProperty"],
+    ["Rune.initClient()", "restrictedObjectProperty"],
+    ["Rune.deterministicRandom(1)", "restrictedObjectProperty"],
     ["Object.assign(window, { hest: 'snel' })", "undef"],
     ['require("hest")', "undef"],
     ['eval("hest")', "undef"],


### PR DESCRIPTION
Next version of the Multiplayer SDK supports randomness, so this PR updates the linter to allow it and adds a section in the docs about it. 