### PR TITLE
build: don't refer to build artifact for rune bin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
           cache: "yarn"
       - run: yarn --prefer-offline --frozen-lockfile --non-interactive --ignore-scripts --silent
       - run: yarn build
+      - run: yarn rune --version
       - run: yarn test
   typecheck:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "husky": "7.0.2",
     "lerna": "^6.1.0",
     "lint-staged": "12.4.1",
-    "prettier": "2.6.2"
+    "prettier": "2.6.2",
+    "rune-games-cli": "4.0.0"
   }
 }

--- a/packages/rune-games-cli/bin/rune.mjs
+++ b/packages/rune-games-cli/bin/rune.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import "../dist/index.js"

--- a/packages/rune-games-cli/package.json
+++ b/packages/rune-games-cli/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Rune AI Inc.",
   "bin": {
-    "rune": "./dist/index.js"
+    "rune": "./bin/rune.mjs"
   },
   "engines": {
     "node": ">=14.17"

--- a/packages/rune-games-cli/src/index.tsx
+++ b/packages/rune-games-cli/src/index.tsx
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import "core-js/actual/array/at.js"
 
 import { ApolloProvider } from "@apollo/client/index.js"


### PR DESCRIPTION
This seems to break the `bin` script when using the workspace as it refers to a file not yet created at the point of installation. 

Steps to validate: 
1. Clone repo fresh. 
2. `yarn`
3. `ls node_modules/.bin/rune`

Last step would fail before this PR, but not with these changes. 