### PR TITLE
fix: binary expression of object properties not allowed

### DIFF
--- a/packages/eslint-plugin-rune/src/rules/no-parent-scope-variables.ts
+++ b/packages/eslint-plugin-rune/src/rules/no-parent-scope-variables.ts
@@ -216,6 +216,7 @@ export const create: Rule.RuleModule["create"] = (context) => {
            */
           if (
             node.parent.object !== node ||
+            node.parent.parent.type === "BinaryExpression" ||
             isRuntimeGlobalVariable(
               findVariable(node.parent.object.name, context.getScope())
             )

--- a/packages/eslint-plugin-rune/test/config/variable-scope.spec.js
+++ b/packages/eslint-plugin-rune/test/config/variable-scope.spec.js
@@ -11,6 +11,7 @@ test("variable scope", {
     "const hest = 'snel'; if (hest = 'klad') { Rune.initLogic(); }",
     "const hest = 'snel'; if (hest === 'klad') { Rune.initLogic(hest); }",
     "const hest = 'snel'; () => { if (hest === 'snel') { return 'klad'; } }",
+    "const hest = { snel: true }; () => { if (hest.snel === true) { return 'klad'; } }",
     "parseInt('1')",
     "let hest; hest === undefined",
     "const hest = null",


### PR DESCRIPTION
Fixes that the following (safe code) wasn't allowed:

```js
const guesses = game.guesses.filter(
  (guess) => guess.round === game.currentRound
)
```