### PR TITLE
feat: allow export statements in logic.js

### DIFF
--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -130,7 +130,7 @@ const logicConfig: ESLint.ConfigData = {
       "error",
       {
         selector:
-          "ImportDeclaration,ExportNamedDeclaration,ExportAllDeclaration,ExportDefaultDeclaration",
+          "ImportDeclaration,ExportNamedDeclaration[source],ExportAllDeclaration[source],ExportDefaultDeclaration[source]",
         message: "Rune logic must be contained in a single file.",
       },
       {

--- a/packages/eslint-plugin-rune/test/config/syntax.spec.js
+++ b/packages/eslint-plugin-rune/test/config/syntax.spec.js
@@ -66,6 +66,8 @@ test("syntax", {
     "switch('hest') { case 'hest': break; default: break; }",
     "let hest = {}; hest.aaa?.bbb",
     "let hest = {}; hest.aaa ?? 'bbb'",
+    'export const hest = "snel"',
+    'export default "hest"',
   ],
   invalid: [
     ["var hest = 'snel'", "unexpectedVar", 1],
@@ -84,9 +86,7 @@ test("syntax", {
     ['import { snel as klad } from "hest"', "restrictedSyntax"],
     ['import * as snel from "hest"', "restrictedSyntax"],
     ['import "hest"', "restrictedSyntax"],
-    ['export const hest = "snel"', "restrictedSyntax"],
     ['export * from "hest"', "restrictedSyntax"],
     ['export { snel } from "hest"', "restrictedSyntax"],
-    ['export default "hest"', "restrictedSyntax"],
   ],
 })


### PR DESCRIPTION
This PR updates the linting config to allow safe export statements for code re-use with client end code. 