### PR TITLE
feat: allow not importing logic.js as a script tag

### DIFF
--- a/packages/rune-games-cli/src/lib/validateGameFiles.test.ts
+++ b/packages/rune-games-cli/src/lib/validateGameFiles.test.ts
@@ -329,24 +329,6 @@ describe("validateGameFiles", () => {
           size: 1 * 1e6,
           content: `
               <html>
-                <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@4.8.1/dist/multiplayer.js"></script>
-              </html>`,
-        },
-      ],
-      {
-        valid: false,
-        errors: [{ message: "logic.js file is not included in index.html" }],
-        multiplayer: {},
-      }
-    )
-
-    await check(
-      [
-        {
-          path: "index.html",
-          size: 1 * 1e6,
-          content: `
-              <html>
                 <script src="logic.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@4.8.1/dist/multiplayer.js"></script>
               </html>`,
@@ -355,7 +337,6 @@ describe("validateGameFiles", () => {
       {
         valid: false,
         errors: [
-          { message: "logic.js must be the second script in index.html" },
           { message: "logic.js must be included in the game files" },
           { message: "Rune SDK must be the first script in index.html" },
         ],
@@ -564,12 +545,58 @@ describe("validateGameFiles", () => {
       {
         valid: false,
         errors: [
-          { message: "logic.js must be in the same directory as index.html" },
           {
             message: "logic.js content has not been provided for validation",
           },
         ],
         multiplayer: {},
+      }
+    )
+
+    await check(
+      [
+        {
+          path: "index.html",
+          size: 1 * 1e6,
+          content: `
+              <html>
+                <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@4.8.1/dist/multiplayer.js"></script>
+                <script src="client.js"></script>
+              </html>`,
+        },
+        {
+          path: "logic.js",
+          size: 1 * 1e6,
+          // language=JavaScript
+          content: `
+              Rune.initLogic({
+                minPlayers: 2,
+                maxPlayers: 4,
+                setup: () => {
+                  return { cells: Array(25).fill(null) }
+                },
+                actions: {},
+                events: {
+                  playerJoined: () => {},
+                  playerLeft () {},
+                },
+              })`,
+        },
+        {
+          path: "client.js",
+          size: 1 * 1e6,
+          content: "import 'logic.js';",
+        },
+      ],
+      {
+        valid: true,
+        errors: [],
+        multiplayer: {
+          handlesPlayerJoined: true,
+          handlesPlayerLeft: true,
+          maxPlayers: 4,
+          minPlayers: 2,
+        },
       }
     )
 

--- a/packages/rune-games-cli/src/lib/validateGameFiles.test.ts
+++ b/packages/rune-games-cli/src/lib/validateGameFiles.test.ts
@@ -545,6 +545,7 @@ describe("validateGameFiles", () => {
       {
         valid: false,
         errors: [
+          { message: "logic.js must be in the same directory as index.html" },
           {
             message: "logic.js content has not been provided for validation",
           },
@@ -561,7 +562,7 @@ describe("validateGameFiles", () => {
           content: `
               <html>
                 <script src="https://cdn.jsdelivr.net/npm/rune-games-sdk@4.8.1/dist/multiplayer.js"></script>
-                <script src="client.js"></script>
+                <script type="module" src="client.js"></script>
               </html>`,
         },
         {

--- a/packages/rune-games-cli/src/lib/validateGameFiles.ts
+++ b/packages/rune-games-cli/src/lib/validateGameFiles.ts
@@ -1,5 +1,6 @@
 import { ESLint, Linter } from "eslint"
 import { parse, valid } from "node-html-parser"
+import path from "path"
 import semver from "semver"
 
 import { extractMultiplayerMetadata } from "./extractMultiplayerMetadata.js"
@@ -95,6 +96,7 @@ export async function validateGameFiles(
           multiplayerValidationResult,
           errors,
           logicJs,
+          indexHtml,
         })
       }
 
@@ -141,16 +143,24 @@ async function validateMultiplayer({
   multiplayerValidationResult,
   errors,
   logicJs,
+  indexHtml,
 }: {
   multiplayerValidationResult: NonNullable<ValidationResult["multiplayer"]>
   errors: ValidationError[]
   logicJs: FileInfo | undefined
+  indexHtml: FileInfo
 }) {
   if (!logicJs) {
     errors.push({
       message: "logic.js must be included in the game files",
     })
   } else {
+    if (path.dirname(indexHtml.path) !== path.dirname(logicJs.path)) {
+      errors.push({
+        message: "logic.js must be in the same directory as index.html",
+      })
+    }
+
     await validateMultiplayerLogicJsContent({
       logicJs,
       multiplayerValidationResult,


### PR DESCRIPTION
Since we now allow exports in the logic file as of #143 along with other changes such as supporting vite, and our vite-template actually not injecting it, it no longer makes sense to require it to be included via a script tag as it might just as well be imported from the client.js itself. 

### Before

<img width="590" alt="Screenshot 2023-05-18 at 10 26 52" src="https://github.com/rune/rune-games-sdk/assets/378279/264d792e-8f5c-43db-b167-17c02852d726">

### After

No errors