### PR TITLE
fix: lint logic.js as esmodule

### DIFF
--- a/packages/rune-games-cli/src/lib/validateGameFiles.ts
+++ b/packages/rune-games-cli/src/lib/validateGameFiles.ts
@@ -24,6 +24,9 @@ const eslint = new ESLint({
   baseConfig: {
     root: true,
     extends: ["plugin:rune/logic"],
+    parserOptions: {
+      sourceType: "module",
+    },
   },
 })
 


### PR DESCRIPTION
Even though we allow exports, eslint will not allow them if sourcetype is not set to `module` and depending on where the lint is run from that differs. This ensures that logic.js is treated as a module and therefore allow exports. 