### PR TITLE
fix: allow imports in non-compiled logic files

### DIFF
--- a/docs/docs/multiplayer/logic-restrictions.md
+++ b/docs/docs/multiplayer/logic-restrictions.md
@@ -35,19 +35,19 @@ Next, add `rune` to the extends section of your `.eslintrc` configuration file:
 
 ```json
 {
-	"extends": ["plugin:rune/recommended"]
+  "extends": ["plugin:rune/recommended"]
 }
 ```
 
-This will exclusively check files named `logic.js` for the Rune Multiplayer SDK rules. If your logic is split across multiple files and a bundler is used to produce a single file, you might specify which files to lint yourself with:
+This will exclusively check files named `logic.js` or files in a `logic` folder for the Rune Multiplayer SDK rules. If your logic is split across multiple files and a bundler is used to produce a single file, you might specify which files to lint yourself with:
 
 ```json
 {
-	"overrides": [
-		{
-			"files": ["logic/*.js"],
-			"extends": ["plugin:rune/logic"]
-		}
-	]
+  "overrides": [
+    {
+      "files": ["lib/*.ts"],
+      "extends": ["plugin:rune/logicModule"]
+    }
+  ]
 }
 ```

--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -2,6 +2,27 @@ import type { ESLint } from "eslint"
 
 export { rules } from "./rules"
 
+const restrictedSyntaxBase = [
+  {
+    selector: "TryStatement",
+    message: "Try/catch might prevent Rune from working properly.",
+  },
+  {
+    selector: "ThisExpression,WithStatement",
+    message: "This references might prevent Rune from working properly.",
+  },
+  {
+    selector:
+      "AwaitExpression,ArrowFunctionExpression[async=true],FunctionExpression[async=true],FunctionDeclaration[async=true],YieldExpression",
+    message: "Rune logic must be synchronous.",
+  },
+  {
+    selector: "RegExpLiteral",
+    message:
+      "Regular expressions are stateful and might prevent Rune from working properly.",
+  },
+]
+
 const logicConfig: ESLint.ConfigData = {
   plugins: ["rune"],
   parserOptions: {
@@ -133,26 +154,17 @@ const logicConfig: ESLint.ConfigData = {
           "ImportDeclaration,ExportNamedDeclaration[source],ExportAllDeclaration[source],ExportDefaultDeclaration[source]",
         message: "Rune logic must be contained in a single file.",
       },
-      {
-        selector: "TryStatement",
-        message: "Try/catch might prevent Rune from working properly.",
-      },
-      {
-        selector: "ThisExpression,WithStatement",
-        message: "This references might prevent Rune from working properly.",
-      },
-      {
-        selector:
-          "AwaitExpression,ArrowFunctionExpression[async=true],FunctionExpression[async=true],FunctionDeclaration[async=true],YieldExpression",
-        message: "Rune logic must be synchronous.",
-      },
-      {
-        selector: "RegExpLiteral",
-        message:
-          "Regular expressions are stateful and might prevent Rune from working properly.",
-      },
+      ...restrictedSyntaxBase,
     ],
     "rune/no-parent-scope-mutation": 2,
+  },
+}
+
+const logicModuleConfig: ESLint.ConfigData = {
+  ...logicConfig,
+  rules: {
+    ...logicConfig.rules,
+    "no-restricted-syntax": ["error", ...restrictedSyntaxBase],
   },
 }
 
@@ -166,7 +178,12 @@ export const configs: ESLint.Plugin["configs"] = {
         files: ["**/logic.js"],
         ...logicConfig,
       },
+      {
+        files: ["**/logic/**/*.ts", "**/logic/**/*.js"],
+        ...logicModuleConfig,
+      },
     ],
   },
   logic: logicConfig,
+  logicModule: logicModuleConfig,
 }


### PR DESCRIPTION
The logic linting rules are useful in development, but we don't allow imports in logic.js, so this adds a separate config excluding that rule.