### PR TITLE
fix: board not resizing properly in outmatched

### DIFF
--- a/multiplayer/examples/outmatched/src/client.ts
+++ b/multiplayer/examples/outmatched/src/client.ts
@@ -69,7 +69,7 @@ const resizeObserver = new ResizeObserver(() => {
     () => {
       const boardWidth =
         Math.floor(
-          Math.min(boardInner.scrollHeight, boardInner.scrollWidth) / rows
+          Math.min(boardInner.clientHeight, boardInner.clientWidth) / rows
         ) * rows
       board.style.width = `${boardWidth}px`
       if (style.sheet?.rules.length !== 0) {

--- a/multiplayer/examples/outmatched/styles.css
+++ b/multiplayer/examples/outmatched/styles.css
@@ -22,6 +22,7 @@ html {
   color: #f9e7d2;
   font-family: LuckiestGuy, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol";
+  overflow-x: hidden;
 }
 
 button:focus {


### PR DESCRIPTION
When adding more players or resizing the window, the board get's stuck at the maximum size and causes scroll to appear, see https://developers.rune.ai/examples/outmatched/

This PR fixes that by disabling horizontal scrolling and not using scroll width for determining element size. 

| Before | After |
|--------|--------|
| <img width="299" alt="Screenshot 2023-05-31 at 12 44 12" src="https://github.com/rune/rune-games-sdk/assets/378279/106a65d5-b926-4a81-b7df-cfc0a49fd858"> | <img width="324" alt="Screenshot 2023-05-31 at 12 44 29" src="https://github.com/rune/rune-games-sdk/assets/378279/0a1e9760-ed4c-47d3-b007-1afb8472241f"> | 

