### PR TITLE
feat: prevent zoom/scroll/dark mode in template

### DIFF
--- a/packages/rune-games-cli/template-vite-react-ts/index.html
+++ b/packages/rune-games-cli/template-vite-react-ts/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/packages/rune-games-cli/template-vite-react-ts/src/index.css
+++ b/packages/rune-games-cli/template-vite-react-ts/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -20,7 +19,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #747bff;
 }
 
 body {
@@ -28,6 +27,7 @@ body {
   display: flex;
   place-items: center;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 h1 {
@@ -42,7 +42,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -51,18 +51,5 @@ button:hover {
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  outline: 0;
 }


### PR DESCRIPTION
For rune games, zooming rarely makes sense, dark mode is disabled and typically you don't want outlines to linger on buttons. This PR updates the template to address these issues.