### PR TITLE
feat: automatically find initial game path after running rune upload

### DIFF
--- a/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
+++ b/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo, useCallback, useEffect } from "react"
 import { Step } from "../../components/Step.js"
 import { ValidationErrors } from "../../components/ValidationErrors.js"
 import { cli } from "../../lib/cli.js"
+import { findGameDir } from "../../lib/findGameDir.js"
 import {
   getGameFiles,
   findShortestPathFileThatEndsWith,
@@ -24,8 +25,8 @@ export function GameDirInputStep({
 }: {
   onComplete: (args: { gameDir: string; multiplayer: boolean }) => void
 }) {
-  const [gameDir, setGameDir] = useState(
-    () => cli.input[1] ?? path.resolve(".")
+  const [gameDir, setGameDir] = useState(() =>
+    findGameDir(cli.input[1] ?? path.resolve("."))
   )
   const gameDirFormatted = useMemo(
     () =>

--- a/packages/rune-games-cli/src/lib/findGameDir.tsx
+++ b/packages/rune-games-cli/src/lib/findGameDir.tsx
@@ -1,0 +1,30 @@
+import fs from "fs"
+import path from "path"
+
+import { parseGameIndexHtml } from "../lib/validateGameFiles.js"
+
+function isGameIndexPath(indexHtmlPath: string) {
+  if (!fs.existsSync(indexHtmlPath)) return false
+
+  const indexHtmlContent = fs.readFileSync(indexHtmlPath, "utf-8")
+
+  const gameIndexHtmlElements = parseGameIndexHtml(indexHtmlContent)
+
+  if (!gameIndexHtmlElements || !gameIndexHtmlElements.sdkScript) return false
+
+  return true
+}
+
+export function findGameDir(dir: string) {
+  const subPaths = ["", "/dist", "/build", "/dist/build", "/build/build"]
+
+  for (const subPath of subPaths) {
+    const indexPath = path.join(dir, subPath, "index.html")
+
+    if (isGameIndexPath(indexPath)) {
+      return path.join(dir, subPath)
+    }
+  }
+
+  return dir
+}


### PR DESCRIPTION
Automatically find initial game path after running `rune upload`.
Try multiple known subpaths before defaulting to the current folder.

### Test plan
Create game with `rune create test` and install packages.

- [x] Run `rune upload` and make sure that "Game directory" points to `./test/dist`
- [x] Copy `./test/dist/index.html` to `./test` folder, run `rune upload` and make sure that "Game directory"  points to `./test`
- [x] Remove `./test/index.html`, run `rune upload` and make sure that "Game directory"  points to `./test`