### PR TITLE
feat: show Invalid directory error when path is not a directory

### DIFF
--- a/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
+++ b/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
@@ -12,6 +12,7 @@ import {
   findShortestPathFileThatEndsWith,
   FileInfo,
 } from "../../lib/getGameFiles.js"
+import { isDir } from "../../lib/isDir.js"
 import {
   validateGameFiles,
   ValidationResult,
@@ -28,6 +29,7 @@ export function GameDirInputStep({
   const [gameDir, setGameDir] = useState(() =>
     findGameDir(cli.input[1] ?? path.resolve("."))
   )
+  const existsGameDir = useMemo(() => isDir(gameDir), [gameDir])
   const gameDirFormatted = useMemo(
     () =>
       path.relative(".", gameDir) === ""
@@ -42,6 +44,8 @@ export function GameDirInputStep({
   const [logicJsFile, setLogicJsFile] = useState<FileInfo | undefined>()
 
   const onSubmitGameDir = useCallback(() => {
+    if (!existsGameDir) return
+
     getGameFiles(gameDir)
       .then((gameFiles) => {
         setLogicJsFile(findShortestPathFileThatEndsWith(gameFiles, "logic.js"))
@@ -49,7 +53,7 @@ export function GameDirInputStep({
         return validateGameFiles(gameFiles)
       })
       .then(setValidateGameResult)
-  }, [gameDir])
+  }, [existsGameDir, gameDir])
 
   useEffect(() => {
     if (validateGameResult?.valid) {
@@ -62,17 +66,29 @@ export function GameDirInputStep({
     validateGameResult?.valid,
   ])
 
+  useEffect(() => {
+    if (!existsGameDir) {
+      setValidateGameResult(null)
+    }
+  }, [existsGameDir])
+
   return (
     <>
-      {!!validateGameResult?.errors.length && (
+      {(!existsGameDir || !!validateGameResult?.errors.length) && (
         <Step
           status="error"
-          label="Some issues detected with your game"
+          label={
+            !existsGameDir
+              ? "Invalid directory"
+              : "Some issues detected with your game"
+          }
           view={
-            <ValidationErrors
-              validationResult={validateGameResult}
-              logicJsFile={logicJsFile}
-            />
+            validateGameResult && (
+              <ValidationErrors
+                validationResult={validateGameResult}
+                logicJsFile={logicJsFile}
+              />
+            )
           }
         />
       )}

--- a/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
+++ b/packages/rune-games-cli/src/flows/Upload/GameDirInputStep.tsx
@@ -79,7 +79,7 @@ export function GameDirInputStep({
           status="error"
           label={
             !existsGameDir
-              ? "Invalid directory"
+              ? "Directory does not exist"
               : "Some issues detected with your game"
           }
           view={

--- a/packages/rune-games-cli/src/lib/isDir.tsx
+++ b/packages/rune-games-cli/src/lib/isDir.tsx
@@ -1,0 +1,5 @@
+import fs from "fs"
+
+export function isDir(dir: string) {
+  return fs.existsSync(dir) && fs.statSync(dir).isDirectory()
+}


### PR DESCRIPTION
In case directory provided `Game directory` path is not a directory display `Directory does not exist` instead of confusing `Some issues detected with your game`.