### PR TITLE
docs: no need to call out multiplayer

### DIFF
--- a/docs/docs/advanced/server-side-logic.md
+++ b/docs/docs/advanced/server-side-logic.md
@@ -6,7 +6,7 @@ sidebar_position: 60
 
 Rune uses a server-authoritative approach to ensure games run smoothly and prevent cheating. To do this, your game's `logic.js` file will run on every client and on Rune's servers (see [Syncing Game State](../how-it-works/syncing-game-state) for more details). Rune ensures that all players see the same thing when playing your game by having some limitations on what kind of code you can write in your `logic.js` file.
 
-The primary aim is to ensure that the code is deterministic, meaning that if you run the code multiple times with the same input it will produce the same result. The main contributors to non-deterministic code in this context is use of other non-deterministic functions such as `Date.now()` and access of shared state such as counters and cache variables. **To avoid errors in production the Rune Multiplayer SDK will check your code** for the following unsafe patterns:
+The primary aim is to ensure that the code is deterministic, meaning that if you run the code multiple times with the same input it will produce the same result. The main contributors to non-deterministic code in this context is use of other non-deterministic functions such as `Date.now()` and access of shared state such as counters and cache variables. **To avoid errors in production the Rune SDK will check your code** for the following unsafe patterns:
 
 - **Mutation and assignment of variables outside of current function scope**. Since mutation of function arguments are allowed for ergonomic reasons, it's also not allowed to read non-local variables, just invoking functions/methods.
 - **`async`/`await` syntax** as logic must be synchronous.
@@ -38,7 +38,7 @@ Next, add `rune` to the extends section of your `.eslintrc` configuration file:
 }
 ```
 
-This will exclusively check files named `logic.js`/`logic.ts` or files in a `logic` folder for the Rune Multiplayer SDK rules. If your logic is split across multiple files and a bundler is used to produce a single file, you might specify which files to lint yourself with:
+This will exclusively check files named `logic.js`/`logic.ts` or files in a `logic` folder for the Rune SDK rules. If your logic is split across multiple files and a bundler is used to produce a single file, you might specify which files to lint yourself with:
 
 ```json
 {

--- a/packages/eslint-plugin-rune/README.md
+++ b/packages/eslint-plugin-rune/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-rune
 
-This package is a collection of rules and configuration for writing safe logic code for the Rune Multiplayer SDK.
+This package is a collection of rules and configuration for writing safe logic code for the Multiplayer SDK.
 
 ## Documentation
 

--- a/packages/eslint-plugin-rune/package.json
+++ b/packages/eslint-plugin-rune/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-rune",
   "version": "0.1.7",
-  "description": "ESlint rules for Rune Multiplayer SDK",
+  "description": "ESlint rules for Multiplayer SDK",
   "license": "MIT",
   "author": "Rune AI Inc.",
   "keywords": [

--- a/packages/vite-plugin-rune/README.md
+++ b/packages/vite-plugin-rune/README.md
@@ -1,6 +1,6 @@
 # vite-plugin-rune
 
-Plugin to use Rune Multiplayer SDK with vite. This plugin will automatically inject the SDK and configure build options to create a `logic.js` file for the game. See [Syncing Game State](https://developers.rune.ai/docs/how-it-works/syncing-game-state) for more info on how Rune's SDK uses a `logic.js` file to seamlessly sync game state across players.
+Plugin to use Rune SDK with vite. This plugin will automatically inject the SDK and configure build options to create a `logic.js` file for the game. See [Syncing Game State](https://developers.rune.ai/docs/how-it-works/syncing-game-state) for more info on how Rune's SDK uses a `logic.js` file to seamlessly sync game state across players.
 
 ## Install
 

--- a/packages/vite-plugin-rune/package.json
+++ b/packages/vite-plugin-rune/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-rune",
   "version": "0.1.1",
   "type": "module",
-  "description": "Vite plugin for Rune Multiplayer SDK",
+  "description": "Vite plugin for Rune SDK",
   "license": "MIT",
   "author": "Rune AI Inc.",
   "keywords": [


### PR DESCRIPTION
Just changing "Rune Multiplayer SDK" -> "Rune SDK" as there's now only a multiplayer version of the SDK.