### PR TITLE
fix: eslint typescript support + recommended config change

### DIFF
--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -129,7 +129,7 @@ const logicModuleConfig: ESLint.ConfigData = {
 export const configs: ESLint.Plugin["configs"] = {
   recommended: {
     globals: {
-      Rune: true,
+      Rune: "readonly",
     },
     overrides: [
       {

--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -79,42 +79,6 @@ const logicConfig: ESLint.ConfigData = {
     ecmaVersion: 2021,
   },
   globals: {
-    // See https://github.com/eslint/eslint/tree/main/conf/globals.js
-    // es3
-    Array: "readonly",
-    Boolean: "readonly",
-    Error: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    hasOwnProperty: "readonly",
-    Infinity: "readonly",
-    isFinite: "readonly",
-    isNaN: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    isPrototypeOf: "readonly",
-    Math: "readonly",
-    NaN: "readonly",
-    Number: "readonly",
-    Object: "readonly",
-    parseFloat: "readonly",
-    parseInt: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    propertyIsEnumerable: "readonly",
-    RangeError: "readonly",
-    ReferenceError: "readonly",
-    String: "readonly",
-    SyntaxError: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    toString: "readonly",
-    TypeError: "readonly",
-    undefined: "readonly",
-    URIError: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    valueOf: "readonly",
-    // es5
-    JSON: "readonly",
-    // es2021
-    AggregateError: "readonly",
-    // Rune globals
     Rune: "readonly",
   },
   rules: {

--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -23,6 +23,56 @@ const restrictedSyntaxBase = [
   },
 ]
 
+const restrictedGlobals = [
+  "exports",
+  "global",
+  "module",
+  "require",
+  "constructor",
+  {
+    name: "Date",
+    message: "Please use Rune.gameTimeInSeconds() for time",
+  },
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURI",
+  "encodeURIComponent",
+  "escape",
+  "eval",
+  "EvalError",
+  "Function",
+  "RegExp",
+  "toLocaleString",
+  "unescape",
+  "ArrayBuffer",
+  "DataView",
+  "Float32Array",
+  "Float64Array",
+  "Int16Array",
+  "Int32Array",
+  "Int8Array",
+  "Promise",
+  "Proxy",
+  "Reflect",
+  "Symbol",
+  "Uint16Array",
+  "Uint32Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "WeakMap",
+  "WeakSet",
+  "Atomics",
+  "SharedArrayBuffer",
+  "BigInt",
+  "BigInt64Array",
+  "BigUint64Array",
+  "globalThis",
+  "FinalizationRegistry",
+  "WeakRef",
+  "Performance",
+  "Intl",
+]
+
 const logicConfig: ESLint.ConfigData = {
   plugins: ["rune"],
   parserOptions: {
@@ -30,27 +80,10 @@ const logicConfig: ESLint.ConfigData = {
   },
   globals: {
     // See https://github.com/eslint/eslint/tree/main/conf/globals.js
-    // commonjs
-    exports: "off",
-    global: "off",
-    module: "off",
-    require: "off",
-
     // es3
     Array: "readonly",
     Boolean: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    constructor: "off",
-    Date: "off",
-    decodeURI: "off",
-    decodeURIComponent: "off",
-    encodeURI: "off",
-    encodeURIComponent: "off",
     Error: "readonly",
-    escape: "off",
-    eval: "off",
-    EvalError: "off",
-    Function: "off",
     // @ts-expect-error JS built-in method conflict
     hasOwnProperty: "readonly",
     Infinity: "readonly",
@@ -68,63 +101,24 @@ const logicConfig: ESLint.ConfigData = {
     propertyIsEnumerable: "readonly",
     RangeError: "readonly",
     ReferenceError: "readonly",
-    RegExp: "off",
     String: "readonly",
     SyntaxError: "readonly",
-    // @ts-expect-error JS built-in method conflict
-    toLocaleString: "off",
     // @ts-expect-error JS built-in method conflict
     toString: "readonly",
     TypeError: "readonly",
     undefined: "readonly",
-    unescape: "off",
     URIError: "readonly",
     // @ts-expect-error JS built-in method conflict
     valueOf: "readonly",
-
     // es5
     JSON: "readonly",
-
-    // es2015
-    ArrayBuffer: "off",
-    DataView: "off",
-    Float32Array: "off",
-    Float64Array: "off",
-    Int16Array: "off",
-    Int32Array: "off",
-    Int8Array: "off",
-    Map: "off",
-    Promise: "off",
-    Proxy: "off",
-    Reflect: "off",
-    Set: "off",
-    Symbol: "off",
-    Uint16Array: "off",
-    Uint32Array: "off",
-    Uint8Array: "off",
-    Uint8ClampedArray: "off",
-    WeakMap: "off",
-    WeakSet: "off",
-
-    // es2017
-    Atomics: "off",
-    SharedArrayBuffer: "off",
-
-    // es2020
-    BigInt: "off",
-    BigInt64Array: "off",
-    BigUint64Array: "off",
-    globalThis: "off",
-
     // es2021
     AggregateError: "readonly",
-    FinalizationRegistry: "off",
-    WeakRef: "off",
-
     // Rune globals
     Rune: "readonly",
   },
   rules: {
+    "no-restricted-globals": ["error", ...restrictedGlobals],
     "no-undef": 2,
     "no-global-assign": 2,
     "no-extend-native": 2,
@@ -175,11 +169,7 @@ export const configs: ESLint.Plugin["configs"] = {
     },
     overrides: [
       {
-        files: ["**/logic.js"],
-        ...logicConfig,
-      },
-      {
-        files: ["**/logic/**/*.ts", "**/logic/**/*.js"],
+        files: ["**/logic.ts", "**/logic.js"],
         ...logicModuleConfig,
       },
     ],

--- a/packages/eslint-plugin-rune/src/rules/no-parent-scope-mutation.ts
+++ b/packages/eslint-plugin-rune/src/rules/no-parent-scope-mutation.ts
@@ -5,7 +5,7 @@ export const meta: Rule.RuleModule["meta"] = {
   type: "problem",
   docs: {
     description:
-      "Only allow mutating and assinging variables in the current function scope",
+      "Only allow mutating and assigning variables in the current function scope",
     recommended: true,
   },
   schema: [],

--- a/packages/eslint-plugin-rune/test/config/globals.spec.js
+++ b/packages/eslint-plugin-rune/test/config/globals.spec.js
@@ -20,6 +20,7 @@ test("globals", () => ({
     "Number.isNaN(12)",
     "if (42 < Infinity) { }",
     "if (typeof Rune === 'undefined') { }",
+    "parseFloat('1.123')",
   ],
   invalid: [
     ["Prune.initLogic()", "no-undef"],
@@ -44,5 +45,6 @@ test("globals", () => ({
     ["Date.now()", "no-restricted-globals"],
     ["new Intl.NumberFormat()", "no-restricted-globals"],
     ["new Symbol()", "no-restricted-globals"],
+    ["parseFloat = function() {}", "no-global-assign"],
   ],
 }))

--- a/packages/eslint-plugin-rune/test/config/globals.spec.js
+++ b/packages/eslint-plugin-rune/test/config/globals.spec.js
@@ -1,11 +1,9 @@
 // @ts-check
 const { createConfigTester } = require("../createConfigTester")
 
-const test = createConfigTester({
-  extends: "plugin:rune/logic",
-})
+const test = createConfigTester()
 
-test("globals", {
+test("globals", () => ({
   valid: [
     "Rune.initLogic()",
     "Math.abs()",
@@ -24,29 +22,27 @@ test("globals", {
     "if (typeof Rune === 'undefined') { }",
   ],
   invalid: [
-    ["Rune.init()", "restrictedObjectProperty"],
-    ["Prune.initLogic()", "undef"],
-    ["Rune.initClient()", "restrictedObjectProperty"],
-    ["Rune.deterministicRandom(1)", "restrictedObjectProperty"],
-    ["Object.assign(window, { hest: 'snel' })", "undef"],
-    ['require("hest")', "undef"],
-    ['eval("hest")', "undef"],
-    ["Date.now()", "undef"],
-    ["new Date()", "undef"],
-    ["const date = Date; date.now()", "undef"],
-    ["Performance.now()", "undef"],
-    ["global.hest = 'snel'", "undef"],
-    ["globalThis.hest = 'snel'", "undef"],
-    ["new XMLHttpRequest()", "undef"],
-    ["fetch('https://rune.ai')", "undef"],
-    ["setTimeout()", "undef"],
-    ["clearTimeout()", "undef"],
-    ["setInterval()", "undef"],
-    ["clearInterval()", "undef"],
-    ["alert()", "undef"],
-    ["new Intl.NumberFormat()", "undef"],
-    ["new Symbol()", "undef"],
-    ["new Map()", "undef"],
-    ["new Set()", "undef"],
+    ["Prune.initLogic()", "no-undef"],
+    ["Object.assign(window, { hest: 'snel' })", "no-undef"],
+    ['require("hest")', "no-undef"],
+    ["Performance.now()", "no-undef"],
+    ["global.hest = 'snel'", "no-undef"],
+    ["globalThis.hest = 'snel'", "no-undef"],
+    ["new XMLHttpRequest()", "no-undef"],
+    ["fetch('https://rune.ai')", "no-undef"],
+    ["setTimeout()", "no-undef"],
+    ["clearTimeout()", "no-undef"],
+    ["setInterval()", "no-undef"],
+    ["clearInterval()", "no-undef"],
+    ["alert()", "no-undef"],
+    ["Rune.init()", "no-restricted-properties"],
+    ["Rune.initClient()", "no-restricted-properties"],
+    ["Rune.deterministicRandom(1)", "no-restricted-properties"],
+    ['eval("hest")', "no-restricted-globals"],
+    ["new Date()", "no-restricted-globals"],
+    ["const date = Date; date.now()", "no-restricted-globals"],
+    ["Date.now()", "no-restricted-globals"],
+    ["new Intl.NumberFormat()", "no-restricted-globals"],
+    ["new Symbol()", "no-restricted-globals"],
   ],
-})
+}))

--- a/packages/eslint-plugin-rune/test/config/parent-scope-mutation.spec.js
+++ b/packages/eslint-plugin-rune/test/config/parent-scope-mutation.spec.js
@@ -1,10 +1,8 @@
 const { createConfigTester } = require("../createConfigTester")
 
-const test = createConfigTester({
-  extends: "plugin:rune/logic",
-})
+const test = createConfigTester()
 
-test("variable scope", {
+test(`variable scope`, ({ type }) => ({
   valid: [
     "(() => { let hest; hest = 'snel' })()",
     "() => { Rune.initLogic() }",
@@ -53,6 +51,7 @@ test("variable scope", {
   ],
   invalid: [
     "let hest; (() => { hest = 'snel' })()",
+    "Math.smth = 4",
     "() => { let hest; () => { hest = 'snel' } }",
     "const hest = ['snel', 'klad']; (() => { hest.splice(0, 1) })()",
     "const hest = { snel: true }; () => Object.assign(hest, { klad: true })",
@@ -74,7 +73,6 @@ test("variable scope", {
     "let hest = 1; () => { ([...hest] = [2]); }",
     "Rune = 'hest'",
     "Rune.blah = 'hest'",
-    "delete Rune",
     "delete Rune.initLogic",
     "Rune.initLogic++",
     "Rune.initLogic += 1",
@@ -89,5 +87,9 @@ test("variable scope", {
     "Object.__defineGetter__(Rune, () => 'hest')",
     "Object.__defineSetter__(Rune, () => 'hest')",
     "Object.setPrototypeOf(Rune, { hest: true })",
-  ].map((s) => [s, "noParentScopeMutation"]),
-})
+    //deleting Rune will throw Parsing error: Deleting local variable in strict mode in case of running in module
+    type === "script" && "delete Rune",
+  ]
+    .filter((x) => !!x)
+    .map((s) => [s, "rune/no-parent-scope-mutation"]),
+}))

--- a/packages/eslint-plugin-rune/test/config/parent-scope-mutation.spec.js
+++ b/packages/eslint-plugin-rune/test/config/parent-scope-mutation.spec.js
@@ -2,7 +2,7 @@ const { createConfigTester } = require("../createConfigTester")
 
 const test = createConfigTester()
 
-test(`variable scope`, ({ type }) => ({
+test("variable scope", ({ type }) => ({
   valid: [
     "(() => { let hest; hest = 'snel' })()",
     "() => { Rune.initLogic() }",

--- a/packages/eslint-plugin-rune/test/config/syntax.spec.js
+++ b/packages/eslint-plugin-rune/test/config/syntax.spec.js
@@ -1,14 +1,9 @@
 // @ts-check
 const { createConfigTester } = require("../createConfigTester")
 
-const test = createConfigTester({
-  extends: "plugin:rune/logic",
-  parserOptions: {
-    sourceType: "module",
-  },
-})
+const test = createConfigTester()
 
-test("syntax", {
+test("syntax", ({ type }) => ({
   valid: [
     "1+1",
     "1-1",
@@ -66,27 +61,34 @@ test("syntax", {
     "switch('hest') { case 'hest': break; default: break; }",
     "let hest = {}; hest.aaa?.bbb",
     "let hest = {}; hest.aaa ?? 'bbb'",
-    'export const hest = "snel"',
-    'export default "hest"',
-  ],
+  ].concat(
+    type === "module"
+      ? ['export const hest = "snel"', 'export default "hest"']
+      : []
+  ),
   invalid: [
-    ["var hest = 'snel'", "unexpectedVar", 1],
-    ["try { throw new Error('hest') } catch (_e) { }", "restrictedSyntax"],
-    ["try { throw new Error('hest') } finally { }", "restrictedSyntax"],
-    ['this.hest = "snel"', "restrictedSyntax"],
-    ['async () => "hest"', "restrictedSyntax"],
-    ['async () => { await Promise.resolve("hest") }', "restrictedSyntax"],
-    ['async function hest() { return "snel" }', "restrictedSyntax"],
+    ["var hest = 'snel'", "no-var", 1],
+    ["try { throw new Error('hest') } catch (_e) { }", "no-restricted-syntax"],
+    ["try { throw new Error('hest') } finally { }", "no-restricted-syntax"],
+    ['this.hest = "snel"', "no-restricted-syntax"],
+    ['async () => "hest"', "no-restricted-syntax"],
+    ['async () => { await Promise.resolve("hest") }', "no-restricted-syntax"],
+    ['async function hest() { return "snel" }', "no-restricted-syntax"],
     [
       'async function hest() { await Promise.resolve("snel") }',
-      "restrictedSyntax",
+      "no-restricted-syntax",
     ],
-    ['function* hest() { yield "snel" }', "restrictedSyntax"],
-    ['import snel from "hest"', "restrictedSyntax"],
-    ['import { snel as klad } from "hest"', "restrictedSyntax"],
-    ['import * as snel from "hest"', "restrictedSyntax"],
-    ['import "hest"', "restrictedSyntax"],
-    ['export * from "hest"', "restrictedSyntax"],
-    ['export { snel } from "hest"', "restrictedSyntax"],
-  ],
-})
+    ['function* hest() { yield "snel" }', "no-restricted-syntax"],
+  ].concat(
+    type === "module"
+      ? [
+          ['import snel from "hest"', "no-restricted-syntax"],
+          ['import { snel as klad } from "hest"', "no-restricted-syntax"],
+          ['import * as snel from "hest"', "no-restricted-syntax"],
+          ['import "hest"', "no-restricted-syntax"],
+          ['export * from "hest"', "no-restricted-syntax"],
+          ['export { snel } from "hest"', "no-restricted-syntax"],
+        ]
+      : []
+  ),
+}))

--- a/packages/eslint-plugin-rune/test/createConfigTester.js
+++ b/packages/eslint-plugin-rune/test/createConfigTester.js
@@ -119,7 +119,7 @@ const createConfigTester = () => {
                             .map(
                               (m) =>
                                 `"${m.message}"${
-                                  m.messageId ? ` (${m.messageId})` : ""
+                                  m.ruleId ? ` (${m.ruleId})` : ""
                                 }`
                             )
                             .join(", ")

--- a/packages/eslint-plugin-rune/test/createConfigTester.js
+++ b/packages/eslint-plugin-rune/test/createConfigTester.js
@@ -36,80 +36,102 @@ const normalizeInvalidCodeTest = (test) => {
   } else if (Array.isArray(test)) {
     return {
       code: test[0],
-      errors: [{ messageId: test[1], severity: test[2] || 2 }],
+      errors: [{ ruleId: test[1], severity: test[2] || 2 }],
     }
   }
   return test
 }
 
-const createConfigTester = (baseConfig = {}) => {
-  const eslint = new ESLint({
-    useEslintrc: false,
-    allowInlineConfig: false,
-    fix: false,
-    cache: false,
-    baseConfig,
-  })
-
+//Need to run tests in :
+//JS script
+//JS module
+//TS script
+//TS module
+const createConfigTester = () => {
   /**
    * @param {string} testName
    * @param {TestSuite} tests
    */
-  return (testName, { valid, invalid }) => {
-    describe(testName, () => {
-      if (valid) {
-        describe("valid", () => {
-          valid.forEach((code) => {
-            it(code, async () => {
-              const [result] = await eslint.lintText(code)
-              assert.deepEqual(
-                result.messages.filter((m) => m.severity >= 1),
-                []
-              )
-            })
-          })
+  return (testName, testGetter) => {
+    ;["typescript", "javascript"].forEach((language) => {
+      ;["module", "script"].forEach((sourceType) => {
+        const eslint = new ESLint({
+          useEslintrc: false,
+          allowInlineConfig: false,
+          fix: false,
+          cache: false,
+          baseConfig: {
+            extends:
+              sourceType === "module"
+                ? "plugin:rune/logicModule"
+                : "plugin:rune/logic",
+            parserOptions: { sourceType },
+            parser:
+              language === "typescript"
+                ? "@typescript-eslint/parser"
+                : undefined,
+          },
         })
-      }
-      if (invalid) {
-        describe("invalid", () => {
-          invalid.forEach((test) => {
-            const { code, errors } = normalizeInvalidCodeTest(test)
-            it(code, async () => {
-              const [result] = await eslint.lintText(code)
-              errors.forEach((error) => {
-                if (
-                  !result.messages.find((message) =>
-                    Object.entries(error).every(
-                      ([key, value]) => message[key] === value
-                    )
+
+        const { valid, invalid } = testGetter({ language, sourceType })
+
+        describe(`${testName}: ${language} ${sourceType}`, () => {
+          if (valid) {
+            describe("valid", () => {
+              valid.forEach((code) => {
+                it(code, async () => {
+                  const [result] = await eslint.lintText(code)
+                  assert.deepEqual(
+                    result.messages.filter((m) => m.severity >= 1),
+                    []
                   )
-                ) {
-                  if (result.messages.length === 0) {
-                    throw new Error(
-                      "Expected error matching " +
-                        JSON.stringify(error) +
-                        ", but none were emitted"
-                    )
-                  }
-                  throw new Error(
-                    "No messages matching " +
-                      JSON.stringify(error) +
-                      " found, but saw " +
-                      result.messages
-                        .map(
-                          (m) =>
-                            `"${m.message}"${
-                              m.messageId ? ` (${m.messageId})` : ""
-                            }`
-                        )
-                        .join(", ")
-                  )
-                }
+                })
               })
             })
-          })
+          }
+          if (invalid) {
+            describe("invalid", () => {
+              invalid.forEach((test) => {
+                const { code, errors } = normalizeInvalidCodeTest(test)
+                it(code, async () => {
+                  const [result] = await eslint.lintText(code)
+                  errors.forEach((error) => {
+                    if (
+                      !result.messages.find((message) =>
+                        Object.entries(error).every(
+                          ([key, value]) => message[key] === value
+                        )
+                      )
+                    ) {
+                      if (result.messages.length === 0) {
+                        throw new Error(
+                          "Expected error matching " +
+                            JSON.stringify(error) +
+                            ", but none were emitted"
+                        )
+                      }
+
+                      throw new Error(
+                        "No messages matching " +
+                          JSON.stringify(error) +
+                          " found, but saw " +
+                          result.messages
+                            .map(
+                              (m) =>
+                                `"${m.message}"${
+                                  m.messageId ? ` (${m.messageId})` : ""
+                                }`
+                            )
+                            .join(", ")
+                      )
+                    }
+                  })
+                })
+              })
+            })
+          }
         })
-      }
+      })
     })
   }
 }

--- a/packages/rune-games-cli/template-vite-react-ts/.eslintrc.cjs
+++ b/packages/rune-games-cli/template-vite-react-ts/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:rune/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: { ecmaVersion: "latest", sourceType: "module" },

--- a/packages/rune-games-cli/template-vite-react-ts/package.json
+++ b/packages/rune-games-cli/template-vite-react-ts/package.json
@@ -25,6 +25,7 @@
     "eslint": "7.22.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
+    "eslint-plugin-rune": "^0.1.7",
     "typescript": "^5.0.2",
     "vite": "^4.3.2",
     "vite-plugin-rune": "^0.1.1"


### PR DESCRIPTION
* Fixes an issue where typescript files were not checked for restrictedGlobals.
* Removes check for Map/Set.
* Updated tests to test code as typescript/javascript + module/script.
* Changed recommended eslint config, now it always treats any logic.js/logic.ts file as module. If users want to do additional customization we should always remember to link to https://developers.rune.ai/docs/advanced/server-side-logic/
* Updated game template to use the rune eslint plugin.