### PR TITLE
feat: vite lint on dev

### DIFF
--- a/packages/rune-games-cli/template-vite-react-ts/package.json
+++ b/packages/rune-games-cli/template-vite-react-ts/package.json
@@ -4,11 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "npm run lint && vite",
     "typecheck": "tsc --noEmit",
     "build": "npm run lint && tsc && vite build",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "test": "exit 0",
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/rune-games-cli/template-vite-react-ts/tsconfig.json
+++ b/packages/rune-games-cli/template-vite-react-ts/tsconfig.json
@@ -15,8 +15,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],


### PR DESCRIPTION
Minor changes to help make dev experience more pleasant:
- Lint when starting dev server to more quickly catch errors
- Remove `max-warnings 0` and TS linting to not fail on e.g. `no-unused-vars` (just print them as warnings)
- Remove irrelevant test command