### PR TITLE
refactor: no lint on dev

### DIFF
--- a/docs/docs/advanced/server-side-logic.md
+++ b/docs/docs/advanced/server-side-logic.md
@@ -23,15 +23,15 @@ The [Rune CLI](publishing/cli.md) will also warn you if it detects that your gam
 
 ## Editor Integration
 
-If you use [ESLint](https://eslint.org/), it's also possible to get warnings for potentially unsafe code directly in your editor.
+If you use [ESLint](https://eslint.org/), you can get warnings for potentially unsafe code directly in your editor!
 
-First, install `eslint-plugin-rune`:
+First, install the Rune eslint plugin:
 
 ```bash
 npm install eslint-plugin-rune --save-dev
 ```
 
-Next, add `rune` to the extends section of your `.eslintrc` configuration file:
+Next, add the plugin to the extends section of your `.eslintrc` configuration file:
 
 ```json
 {

--- a/packages/rune-games-cli/template-vite-react-ts/package.json
+++ b/packages/rune-games-cli/template-vite-react-ts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run lint && vite",
+    "dev": "vite",
     "typecheck": "tsc --noEmit",
     "build": "npm run lint && tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",


### PR DESCRIPTION
Revert eslint linting on dev for quick start template.

Also add in a quick doc tweak to emphasize eslint linting.