### PR TITLE
docs: remove playerJoined, playerLeft from template

### DIFF
--- a/packages/rune-games-cli/template-vite-react-ts/src/logic.ts
+++ b/packages/rune-games-cli/template-vite-react-ts/src/logic.ts
@@ -27,12 +27,4 @@ Rune.initLogic({
       game.count += amount
     },
   },
-  events: {
-    playerJoined: () => {
-      // Handle player joined
-    },
-    playerLeft() {
-      // Handle player left
-    },
-  },
 })


### PR DESCRIPTION
Remove these fields from the template as new devs think they're mandatory when they're optional.