### PR TITLE
feat: show QR code when using rune create and yarn dev

### DIFF
--- a/packages/rune-games-cli/template-vite-react-ts/package.json
+++ b/packages/rune-games-cli/template-vite-react-ts/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-rune": "^0.1.9",
     "typescript": "^5.0.2",
     "vite": "^4.3.2",
+    "vite-plugin-qrcode": "^0.2.2",
     "vite-plugin-rune": "^0.1.1"
   }
 }

--- a/packages/rune-games-cli/template-vite-react-ts/package.json
+++ b/packages/rune-games-cli/template-vite-react-ts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "typecheck": "tsc --noEmit",
     "build": "npm run lint && tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",

--- a/packages/rune-games-cli/template-vite-react-ts/vite.config.ts
+++ b/packages/rune-games-cli/template-vite-react-ts/vite.config.ts
@@ -8,8 +8,8 @@ import path from "node:path"
 export default defineConfig({
   base: "", // Makes paths relative
   plugins: [
-    qrcode(),
-    react(), // only applies in dev mode
+    qrcode(), // only applies in dev mode
+    react(),
     rune({ logicPath: path.resolve("./src/logic.ts") }),
   ],
 })

--- a/packages/rune-games-cli/template-vite-react-ts/vite.config.ts
+++ b/packages/rune-games-cli/template-vite-react-ts/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite"
+import { qrcode } from "vite-plugin-qrcode"
 import react from "@vitejs/plugin-react"
 import rune from "vite-plugin-rune"
 import path from "node:path"
@@ -6,5 +7,9 @@ import path from "node:path"
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "", // Makes paths relative
-  plugins: [react(), rune({ logicPath: path.resolve("./src/logic.ts") })],
+  plugins: [
+    qrcode(),
+    react(), // only applies in dev mode
+    rune({ logicPath: path.resolve("./src/logic.ts") }),
+  ],
 })


### PR DESCRIPTION
Show QR code when using `rune create` and running `yarn dev`.
Run `yarn dev` with `--host`.

### Test plan
- [x] Run `rune create test && cd test && yarn && yarn dev`. Make sure QR code shows
- [x] Scan QR code with mobile, open the page. Make sure "Vite + Rune" app loads 