### PR TITLE
feat: upload preview img by admin using rune update-info

### DIFF
--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -19,6 +19,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
   const [descriptionSubmitted, setDescriptionSubmitted] = useState(false)
   const [logoPath, setLogoPath] = useState("")
   const [logoPathSubmitted, setLogoPathSubmitted] = useState(false)
+  const [previewImgPath, setPreviewImgPath] = useState("")
+  const [previewImgPathSubmitted, setPreviewImgPathSubmitted] = useState(false)
   const { updateGame, updateGameLoading, updateGameError, updatedGame } =
     useUpdateGame()
 
@@ -33,14 +35,25 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
   const onSubmitLogoPath = useCallback(() => {
     setLogoPathSubmitted(true)
   }, [])
+  const onSubmitPreviewImgPath = useCallback(() => {
+    setPreviewImgPathSubmitted(true)
+  }, [])
 
   useEffect(() => {
-    if (titleSubmitted && descriptionSubmitted && logoPathSubmitted) {
+    if (
+      titleSubmitted &&
+      descriptionSubmitted &&
+      logoPathSubmitted &&
+      previewImgPathSubmitted
+    ) {
       updateGame({
         gameId,
         title,
         description,
         ...(logoPath && { logo: prepareFileUpload(logoPath) }),
+        ...(previewImgPath && {
+          previewImg: prepareFileUpload(previewImgPath),
+        }),
       })
     }
   }, [
@@ -49,6 +62,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
     gameId,
     logoPath,
     logoPathSubmitted,
+    previewImgPath,
+    previewImgPathSubmitted,
     title,
     titleSubmitted,
     updateGame,
@@ -59,6 +74,7 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
       setTitleSubmitted(false)
       setDescriptionSubmitted(false)
       setLogoPathSubmitted(false)
+      setPreviewImgPathSubmitted(false)
     }
   }, [updateGameError])
 
@@ -128,6 +144,28 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
                 value={logoPath}
                 onChange={setLogoPath}
                 onSubmit={onSubmitLogoPath}
+              />
+            )
+          }
+        />
+      )}
+      {logoPathSubmitted && (
+        <Step
+          status={previewImgPathSubmitted ? "success" : "userInput"}
+          label={
+            previewImgPathSubmitted
+              ? previewImgPath === ""
+                ? "Will not update the game preview image"
+                : `Will update the preview image to the one from ${previewImgPath}`
+              : "Provide path to game preview image (optional)"
+          }
+          view={
+            !previewImgPathSubmitted && (
+              <TextInput
+                placeholder="/path/to/preview_img.png"
+                value={previewImgPath}
+                onChange={setPreviewImgPath}
+                onSubmit={onSubmitPreviewImgPath}
               />
             )
           }

--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useEffect } from "react"
 
 import { Step } from "../../components/Step.js"
 import { useGame } from "../../gql/useGame.js"
+import { useMe } from "../../gql/useMe.js"
 import { useUpdateGame } from "../../gql/useUpdateGame.js"
 import { formatApolloError } from "../../lib/formatApolloError.js"
 import { prepareFileUpload } from "../../lib/prepareFileUpload.js"
@@ -12,6 +13,9 @@ import { prepareFileUpload } from "../../lib/prepareFileUpload.js"
 const TextInput = TextInputImport.default as typeof TextInputImport
 
 export function UpdateGameStep({ gameId }: { gameId: number }) {
+  const { me } = useMe()
+  const isAdmin = Boolean(me?.admin)
+
   const { game } = useGame(gameId)
   const [title, setTitle] = useState("")
   const [titleSubmitted, setTitleSubmitted] = useState(false)
@@ -44,7 +48,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
       titleSubmitted &&
       descriptionSubmitted &&
       logoPathSubmitted &&
-      previewImgPathSubmitted
+      // Only allow admin to upload previewImg
+      (!isAdmin || previewImgPathSubmitted)
     ) {
       updateGame({
         gameId,
@@ -57,6 +62,7 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
       })
     }
   }, [
+    isAdmin,
     description,
     descriptionSubmitted,
     gameId,
@@ -149,7 +155,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
           }
         />
       )}
-      {logoPathSubmitted && (
+      {/* Only allow admin to upload previewImg */}
+      {logoPathSubmitted && isAdmin && (
         <Step
           status={previewImgPathSubmitted ? "success" : "userInput"}
           label={

--- a/packages/rune-games-cli/src/generated/types.ts
+++ b/packages/rune-games-cli/src/generated/types.ts
@@ -567,6 +567,7 @@ export interface UpdateGameInput {
   description?: InputMaybe<Scalars['String']>;
   gameId: Scalars['Int'];
   logo?: InputMaybe<Scalars['Upload']>;
+  previewImg?: InputMaybe<Scalars['Upload']>;
   title?: InputMaybe<Scalars['String']>;
 }
 


### PR DESCRIPTION
Ask for optional preview img when admin runs `rune update-info`.

### Test plan
- [x] Run `rune update-info` as admin and use default data.
- [x] Run `rune update-info` as admin and update all data. Make sure new logo and preview img got uploaded
- [x] Rune `rune update-info` as normal user and use default data.
- [x] Rune `rune update-info` as normal user and update all data. Make sure you cannot see preview img and that all other data got successfully updated.