### PR TITLE
fix: update both title and description when running rune update-info

### DIFF
--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -63,11 +63,15 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
   }, [updateGameError])
 
   useEffect(() => {
+    // Set initial values of game
     if (game) {
-      setTitle(game.title)
-      if (game.description) setDescription(game.description)
+      if (!titleSubmitted) setTitle(game.title)
+
+      if (!descriptionSubmitted && game.description) {
+        setDescription(game.description)
+      }
     }
-  }, [game])
+  }, [titleSubmitted, descriptionSubmitted, game])
 
   return (
     <Box flexDirection="column">

--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -13,6 +13,7 @@ const TextInput = TextInputImport.default as typeof TextInputImport
 
 export function UpdateGameStep({ gameId }: { gameId: number }) {
   const { game } = useGame(gameId)
+  const [initialValuesSet, setInitialValuesSet] = useState(false)
   const [title, setTitle] = useState("")
   const [titleSubmitted, setTitleSubmitted] = useState(false)
   const [description, setDescription] = useState("")
@@ -63,15 +64,18 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
   }, [updateGameError])
 
   useEffect(() => {
-    // Set initial values of game
-    if (game) {
-      if (!titleSubmitted) setTitle(game.title)
+    if (initialValuesSet) return
 
-      if (!descriptionSubmitted && game.description) {
+    if (game) {
+      setTitle(game.title)
+
+      if (game.description) {
         setDescription(game.description)
       }
+
+      setInitialValuesSet(true)
     }
-  }, [titleSubmitted, descriptionSubmitted, game])
+  }, [initialValuesSet, game])
 
   return (
     <Box flexDirection="column">


### PR DESCRIPTION
Currently, when both title and description are being updated during `rune update-info`, only `title` gets updated.
This PR fixes this bug.

### Test plan
- [x] Run `rune update-info` and select game. Make sure both title and description are pre-filled
- [x] Update both title and description and ignore logo. Make sure both title and description are saved