### PR TITLE
fix: make photographer more visible

### DIFF
--- a/examples/pinpoint/src/components/ScoreboardView/ScoreboardView.tsx
+++ b/examples/pinpoint/src/components/ScoreboardView/ScoreboardView.tsx
@@ -220,7 +220,7 @@ const ListContainer = styled.div`
 
 const WhiteBackground = styled(Overlay)`
   background-color: #F8FFFC;
-  opacity: 0.8;
+  opacity: 0.9;
 `
 
 const GreenCircle = styled.img`

--- a/examples/pinpoint/src/components/ScoreboardView/ScoreboardView.tsx
+++ b/examples/pinpoint/src/components/ScoreboardView/ScoreboardView.tsx
@@ -219,8 +219,8 @@ const ListContainer = styled.div`
 `
 
 const WhiteBackground = styled(Overlay)`
-  background-color: white;
-  opacity: 0.6;
+  background-color: #F8FFFC;
+  opacity: 0.8;
 `
 
 const GreenCircle = styled.img`


### PR DESCRIPTION
Pinpoint Game
* Change overlay color and opacity to make photographer name more visible

<img width="300" src="https://github.com/rune/rune-games-sdk/assets/3238370/ca15a5c0-513f-4484-95cd-f786a756bd71" />
