### PR TITLE
fix: remove local stage

### DIFF
--- a/packages/rune-games-cli/package.json
+++ b/packages/rune-games-cli/package.json
@@ -23,7 +23,7 @@
     "node": ">=14.17"
   },
   "scripts": {
-    "rune": "STAGE=local ts-node --esm src",
+    "rune": "ts-node --esm src",
     "build": "rm -rf dist && tsc && chmod +x dist/index.js",
     "build:cjs": "rm -rf cjs && tsc --project tsconfig-cjs.json && echo '{ \"type\": \"commonjs\" }' > cjs/package.json && git checkout cjs/lib/rootPath.js",
     "prepublishOnly": "yarn build && yarn build:cjs",


### PR DESCRIPTION
If anyone contributes they won't have access to locally running server, so this will in turn make requests to the production server by default.