### PR TITLE
feat: dont minify logic file

### DIFF
--- a/packages/vite-plugin-rune/package.json
+++ b/packages/vite-plugin-rune/package.json
@@ -38,14 +38,19 @@
   },
   "devDependencies": {
     "@jest/globals": "29.3.1",
-    "rune-games-sdk": "^4.16.0",
-    "typescript": "^4.9.3",
-    "vite": "^4.3.2",
+    "@types/terser": "^3.12.0",
     "jest": "29.3.1",
-    "ts-jest": "29.0.3"
+    "rune-games-sdk": "^4.16.0",
+    "ts-jest": "29.0.3",
+    "typescript": "^4.9.3",
+    "vite": "^4.3.2"
   },
   "peerDependencies": {
     "rune-games-sdk": ">=4.16.0",
     "vite": "^4"
+  },
+  "dependencies": {
+    "okie": "^1.0.1",
+    "terser": "^5.22.0"
   }
 }

--- a/packages/vite-plugin-rune/src/index.ts
+++ b/packages/vite-plugin-rune/src/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite"
 import { createRequire } from "node:module"
 import path from "node:path"
 import { existsSync, readFileSync } from "node:fs"
+import { terserPlugin } from "./terser.js"
 
 const require = createRequire(import.meta.url)
 
@@ -108,5 +109,6 @@ export default function runePlugin(options: ViteRunePluginOptions): Plugin[] {
         },
       }),
     },
+    terserPlugin(),
   ]
 }

--- a/packages/vite-plugin-rune/src/terser.ts
+++ b/packages/vite-plugin-rune/src/terser.ts
@@ -1,0 +1,71 @@
+import { Worker } from "okie"
+import type { Plugin } from "vite"
+import type { MinifyOptions, MinifyOutput } from "terser"
+
+//Vite does not allow to disable minification for a specific file.
+//This plugin in turn disables minifation on all files, and then runs it on all files except logic.js
+//Implemented using https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/terser.ts as inspiration
+//And adapted according to https://rollupjs.org/plugin-development/#output-generation-hooks chart, so that this plugin runs after esbuild is done.
+export function terserPlugin(): Plugin {
+  const makeWorker = () =>
+    new Worker(
+      async (code: string, options: MinifyOptions) => {
+        // test fails when using `import`. maybe related: https://github.com/nodejs/node/issues/43205
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const terser = require("terser")
+        return terser.minify(code, options) as MinifyOutput
+      },
+      {
+        max: undefined,
+      }
+    )
+
+  let worker: ReturnType<typeof makeWorker>
+
+  let shouldMinify = true
+
+  return {
+    name: "vite:rune-plugin:minify",
+    apply: "build",
+    //Disable minification for all files
+    config: (config) => {
+      //In case user manually disables minification, we'll skip running it for all files too.
+      if (config.build?.minify === false) {
+        shouldMinify = false
+      }
+
+      return {
+        ...config,
+        build: {
+          minify: false,
+        },
+      }
+    },
+    async generateBundle(outputOptions, bundle) {
+      worker || (worker = makeWorker())
+
+      await Promise.all(
+        Object.keys(bundle).map(async (name) => {
+          if (!shouldMinify || name === "logic.js") {
+            return
+          }
+
+          const chunk = bundle[name]
+
+          if ("code" in chunk) {
+            const res = await worker.run(chunk.code, {
+              module: outputOptions.format.startsWith("es"),
+              toplevel: outputOptions.format === "cjs",
+            })
+
+            chunk.code = res.code || ""
+          }
+        })
+      )
+    },
+
+    closeBundle() {
+      worker?.stop()
+    },
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,6 +1799,15 @@
     "@jridgewell/set-array" "^1.0.0"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
@@ -1822,6 +1831,14 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.5.tgz#a3bb4d5c6825aab0d281268f47f6ad5853431e91"
+  integrity sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
@@ -3195,6 +3212,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/terser@^3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@types/terser/-/terser-3.12.0.tgz#25e020fe9a7a6ae92ce46261f00ced67de6c12ac"
+  integrity sha512-J0Wy8A7ULEqVJftkWhrXZbH0iBk4tYuTj0gBiiveKaY9deNi6cCsxl0ApJ27ojqwYv51bvEw85lOb8Wt4ng9zA==
+  dependencies:
+    terser "*"
+
 "@types/tough-cookie@*":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.3.tgz#3d06b6769518450871fbc40770b7586334bdfd90"
@@ -3418,7 +3442,7 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.8.1:
+acorn@^8.1.0, acorn@^8.8.1, acorn@^8.8.2:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -4426,6 +4450,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^8.3.0:
   version "8.3.0"
@@ -8889,6 +8918,11 @@ object.values@^1.1.5, object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+okie@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/okie/-/okie-1.0.1.tgz#5ce8e5bd21606988514fccd1c5e3a5e1fb0b37d5"
+  integrity sha512-JQh5TdSYhzXSuKN3zzX8Rw9Q/Tec1fm0jwP/k9+cBDk6tyLjlARVu936MLY//2NZp76UGHH+5gXPzRejU1bTjQ==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
@@ -10158,6 +10192,14 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -10505,6 +10547,16 @@ temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
+
+terser@*, terser@^5.22.0:
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.22.0.tgz#4f18103f84c5c9437aafb7a14918273310a8a49d"
+  integrity sha512-hHZVLgRA2z4NWcN6aS5rQDc+7Dcy58HOf2zbYwmFcQ+ua3h6eEFf5lIDKTzbWwlazPyOZsFQO8V80/IjVNExEw==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Currently we run `logic.js` validation before uploading the game.

There is a big chance that user didn't make any mistakes in their logic code, but they've imported some 3rd party code, which is written not following the necessary rules.

Since we minify the logic.js code, its becomes more or less impossible to understand what is going on.

This PR stops minifying logic.js code.