### PR TITLE
refactor: update repo references after renaming repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
           # This token is required only if you have configured to store the signatures in a remote repository/organization
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
-          path-to-document: 'https://github.com/rune/rune-games-sdk/blob/staging/CLA.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/rune/rune/blob/staging/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           allowlist: AmaniAlbrecht,bfelbo,helios1138,LyndaMcD,mieszko4,mzbyszynski,rune-ci,sanjaypojo,shanehelm72,Gongreg
 
@@ -35,4 +35,4 @@ jobs:
           lock-pullrequest-aftermerge: false
           branch: main
           path-to-signatures: cla.json
-          custom-notsigned-prcomment: '<br/>Thank you for your submission, we really appreciate it! Like many open-source projects, we ask that you read and sign our [Contributor License Agreement](https://github.com/rune/rune-games-sdk/blob/staging/CLA.md) before we can accept your contribution. You can sign the CLA by posting a comment on this PR using the text below.<br/>'
+          custom-notsigned-prcomment: '<br/>Thank you for your submission, we really appreciate it! Like many open-source projects, we ask that you read and sign our [Contributor License Agreement](https://github.com/rune/rune/blob/staging/CLA.md) before we can accept your contribution. You can sign the CLA by posting a comment on this PR using the text below.<br/>'

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Build multiplayer web games that run inside Rune on [Android](https://play.googl
 
 ## Packages
 
-- [`eslint-plugin-rune`](https://github.com/rune/rune-games-sdk/tree/staging/packages/eslint-plugin-rune) – collection of rules and configuration for writing safe logic code for the Rune SDK
-- [`rune-games-cli`](https://github.com/rune/rune-games-sdk/tree/staging/packages/rune-games-cli) – command line tool to develop and upload your HTML5 game for Rune
-- [`vite-plugin-rune`](https://github.com/rune/rune-games-sdk/tree/staging/packages/vite-plugin-rune) – Vite plugin for writing games for the Rune SDK
+- [`eslint-plugin-rune`](https://github.com/rune/rune/tree/staging/packages/eslint-plugin-rune) – collection of rules and configuration for writing safe logic code for the Rune SDK
+- [`rune-games-cli`](https://github.com/rune/rune/tree/staging/packages/rune-games-cli) – command line tool to develop and upload your HTML5 game for Rune
+- [`vite-plugin-rune`](https://github.com/rune/rune/tree/staging/packages/vite-plugin-rune) – Vite plugin for writing games for the Rune SDK
 
 ## Examples
 
 | Tic Tac Toe                                                                                                                                  | Outmatched                                                                                                                                 | Sudoku                                                                                                                             | Pinpoint                                                                                                                               |
 | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | [<img src="docs/static/img/multiplayer-games/tic-tac-toe.png" width=500>](https://developers.rune.ai/examples/tic-tac-toe/)                  | [<img src="docs/static/img/multiplayer-games/outmatched.png" width=500>](https://developers.rune.ai/examples/outmatched/)                  | [<img src="docs/static/img/multiplayer-games/sudoku.png" width=500>](https://developers.rune.ai/examples/sudoku/)                  | [<img src="docs/static/img/multiplayer-games/pinpoint.png" width=500>](https://developers.rune.ai/examples/pinpoint/)                  |
-| [Demo](https://developers.rune.ai/examples/tic-tac-toe/), [Source](https://github.com/rune/rune-games-sdk/tree/staging/examples/tic-tac-toe) | [Demo](https://developers.rune.ai/examples/outmatched/), [Source](https://github.com/rune/rune-games-sdk/tree/staging/examples/outmatched) | [Demo](https://developers.rune.ai/examples/sudoku/), [Source](https://github.com/rune/rune-games-sdk/tree/staging/examples/sudoku) | [Demo](https://developers.rune.ai/examples/pinpoint/), [Source](https://github.com/rune/rune-games-sdk/tree/staging/examples/pinpoint) |
+| [Demo](https://developers.rune.ai/examples/tic-tac-toe/), [Source](https://github.com/rune/rune/tree/staging/examples/tic-tac-toe) | [Demo](https://developers.rune.ai/examples/outmatched/), [Source](https://github.com/rune/rune/tree/staging/examples/outmatched) | [Demo](https://developers.rune.ai/examples/sudoku/), [Source](https://github.com/rune/rune/tree/staging/examples/sudoku) | [Demo](https://developers.rune.ai/examples/pinpoint/), [Source](https://github.com/rune/rune/tree/staging/examples/pinpoint) |
 
 ## Help
 
-If you're having trouble, please feel free to file an issue in our [GitHub issue tracker](https://github.com/rune/rune-games-sdk/issues) or join our [Discord server](https://discord.gg/rune-devs).
+If you're having trouble, please feel free to file an issue in our [GitHub issue tracker](https://github.com/rune/rune/issues) or join our [Discord server](https://discord.gg/rune-devs).
 
 ## Contributing
 

--- a/docs/docs/advanced/real-time-games.md
+++ b/docs/docs/advanced/real-time-games.md
@@ -119,5 +119,5 @@ Player A's `onChange` function will now be called with `timeSync` event to recon
 
 ## Further Reading
 
-- [See how the Pinpoint example game uses time](https://github.com/rune/rune-games-sdk/blob/staging/examples/pinpoint/src/logic.ts)
+- [See how the Pinpoint example game uses time](https://github.com/rune/rune/blob/staging/examples/pinpoint/src/logic.ts)
 - [See how to reduce stutters in fast-paced games](reducing-stutter.md)

--- a/docs/docs/advanced/reducing-stutter.md
+++ b/docs/docs/advanced/reducing-stutter.md
@@ -158,4 +158,4 @@ function onChange({ previousGame, game }) {
 
 ## Demo and Example Game
 
-Using the interpolations described above, your game can achieve flexible frame rate rendering and smooth movements for other players regardless of network conditions. This gives the best player experience for the games that need it. If you want to make your own real-time Rune game, it's great to start with the Paddle example game. You can [try the demo](/examples/paddle) and see how the opponent gets interpolated when simulating latency. You can also see the [full code here](https://github.com/rune/rune-games-sdk/blob/staging/examples/paddle)!
+Using the interpolations described above, your game can achieve flexible frame rate rendering and smooth movements for other players regardless of network conditions. This gives the best player experience for the games that need it. If you want to make your own real-time Rune game, it's great to start with the Paddle example game. You can [try the demo](/examples/paddle) and see how the opponent gets interpolated when simulating latency. You can also see the [full code here](https://github.com/rune/rune/blob/staging/examples/paddle)!

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -101,7 +101,7 @@ How many milliseconds user action is delayed before notifying client. Allowed va
 
 Whenever a player tries to do an action that is not allowed, the action handler should reject it by calling `throw Rune.invalidAction()` which will cancel the action and roll back any local optimistic updates.
 
-This is completely safe to do and can be used throughout your game. For instance, it is used in the [Tic Tac Toe example](https://github.com/rune/rune-games-sdk/blob/staging/examples/tic-tac-toe/logic.js) to ensure that players only can make a move when it is their turn.
+This is completely safe to do and can be used throughout your game. For instance, it is used in the [Tic Tac Toe example](https://github.com/rune/rune/blob/staging/examples/tic-tac-toe/logic.js) to ensure that players only can make a move when it is their turn.
 
 ```js
 // logic.js

--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -60,4 +60,4 @@ import { MultiplayerExamples } from "@site/src/components/MultiplayerExamples"
   ]}
 />
 
-See all multiplayer examples in our [GitHub repository](https://github.com/rune/rune-games-sdk/tree/staging/examples/) and see all the types of [games supported on Rune](publishing/supported-games.md).
+See all multiplayer examples in our [GitHub repository](https://github.com/rune/rune/tree/staging/examples/) and see all the types of [games supported on Rune](publishing/supported-games.md).

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -129,7 +129,7 @@ const config = {
               },
               {
                 label: "GitHub",
-                href: "https://github.com/rune/rune-games-sdk",
+                href: "https://github.com/rune/rune",
               },
             ],
           },

--- a/docs/src/components/MultiplayerExamples/index.js
+++ b/docs/src/components/MultiplayerExamples/index.js
@@ -13,7 +13,7 @@ export function MultiplayerExamples({ data }) {
           <h2>{example.title}</h2>
           <a href={`/examples/${example.slug}/`}>Demo</a> |{" "}
           <a
-            href={`https://github.com/rune/rune-games-sdk/tree/staging/examples/${example.slug}`}
+            href={`https://github.com/rune/rune/tree/staging/examples/${example.slug}`}
           >
             Source
           </a>

--- a/docs/src/components/Social.js
+++ b/docs/src/components/Social.js
@@ -5,7 +5,7 @@ export function Social() {
   return (
     <>
       <a
-        href="https://github.com/rune/rune-games-sdk"
+        href="https://github.com/rune/rune"
         target="_blank"
         rel="noreferrer"
         className={styles.socialLink}

--- a/docs/src/theme/Navbar/Layout/index.js
+++ b/docs/src/theme/Navbar/Layout/index.js
@@ -77,7 +77,7 @@ export default function NavbarLayout() {
           FAQ
         </Link>
         <a
-          href="https://github.com/rune/rune-games-sdk"
+          href="https://github.com/rune/rune"
           target="_blank"
           rel="noreferrer"
           className={styles.menuBtn}

--- a/packages/eslint-plugin-rune/package.json
+++ b/packages/eslint-plugin-rune/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rune/rune-games-sdk.git",
+    "url": "git+https://github.com/rune/rune.git",
     "directory": "packages/eslint-plugin-rune"
   },
   "main": "./dist/index.js",

--- a/packages/interpolators/package.json
+++ b/packages/interpolators/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rune/rune-games-sdk.git",
+    "url": "git+https://github.com/rune/rune.git",
     "directory": "packages/interpolators"
   },
   "scripts": {

--- a/packages/rune-games-cli/package.json
+++ b/packages/rune-games-cli/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rune/rune-games-sdk.git",
+    "url": "git+https://github.com/rune/rune.git",
     "directory": "packages/rune-games-cli"
   },
   "author": "Rune AI Inc.",

--- a/packages/vite-plugin-rune/package.json
+++ b/packages/vite-plugin-rune/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rune/rune-games-sdk.git",
+    "url": "git+https://github.com/rune/rune.git",
     "directory": "packages/vite-plugin-rune"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
I've updated all references to this repo after it's been renamed. I've not updated any references to `rune-games-sdk` that refer to the SDK code distributed via npm.