### PR TITLE
feat: upload game preview img instead of logo

### DIFF
--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -22,10 +22,10 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
   const [titleSubmitted, setTitleSubmitted] = useState(false)
   const [description, setDescription] = useState("")
   const [descriptionSubmitted, setDescriptionSubmitted] = useState(false)
-  const [logoPath, setLogoPath] = useState("")
-  const [logoPathSubmitted, setLogoPathSubmitted] = useState(false)
   const [previewImgPath, setPreviewImgPath] = useState("")
   const [previewImgPathSubmitted, setPreviewImgPathSubmitted] = useState(false)
+  const [logoPath, setLogoPath] = useState("")
+  const [logoPathSubmitted, setLogoPathSubmitted] = useState(false)
   const { updateGame, updateGameLoading, updateGameError, updatedGame } =
     useUpdateGame()
 
@@ -37,29 +37,30 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
     setDescriptionSubmitted(true)
   }, [])
 
-  const onSubmitLogoPath = useCallback(() => {
-    setLogoPathSubmitted(true)
-  }, [])
   const onSubmitPreviewImgPath = useCallback(() => {
     setPreviewImgPathSubmitted(true)
+  }, [])
+
+  const onSubmitLogoPath = useCallback(() => {
+    setLogoPathSubmitted(true)
   }, [])
 
   useEffect(() => {
     if (
       titleSubmitted &&
       descriptionSubmitted &&
-      logoPathSubmitted &&
-      // Only allow admin to upload previewImg
-      (!isAdmin || previewImgPathSubmitted)
+      previewImgPathSubmitted &&
+      // Only allow admin to upload logo
+      (!isAdmin || logoPathSubmitted)
     ) {
       updateGame({
         gameId,
         title,
         description,
-        ...(logoPath && { logo: prepareFileUpload(logoPath) }),
         ...(previewImgPath && {
           previewImg: prepareFileUpload(previewImgPath),
         }),
+        ...(logoPath && { logo: prepareFileUpload(logoPath) }),
       })
     }
   }, [
@@ -67,10 +68,10 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
     description,
     descriptionSubmitted,
     gameId,
-    logoPath,
-    logoPathSubmitted,
     previewImgPath,
     previewImgPathSubmitted,
+    logoPath,
+    logoPathSubmitted,
     title,
     titleSubmitted,
     updateGame,
@@ -80,8 +81,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
     if (updateGameError) {
       setTitleSubmitted(false)
       setDescriptionSubmitted(false)
-      setLogoPathSubmitted(false)
       setPreviewImgPathSubmitted(false)
+      setLogoPathSubmitted(false)
     }
   }, [updateGameError])
 
@@ -143,29 +144,6 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
       )}
       {descriptionSubmitted && (
         <Step
-          status={logoPathSubmitted ? "success" : "userInput"}
-          label={
-            logoPathSubmitted
-              ? logoPath === ""
-                ? "Will not update the game logo"
-                : `Will update the logo to the one from ${logoPath}`
-              : "Provide path to game logo (optional)"
-          }
-          view={
-            !logoPathSubmitted && (
-              <TextInput
-                placeholder="/path/to/logo.png"
-                value={logoPath}
-                onChange={setLogoPath}
-                onSubmit={onSubmitLogoPath}
-              />
-            )
-          }
-        />
-      )}
-      {/* Only allow admin to upload previewImg */}
-      {logoPathSubmitted && isAdmin && (
-        <Step
           status={previewImgPathSubmitted ? "success" : "userInput"}
           label={
             previewImgPathSubmitted
@@ -181,6 +159,29 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
                 value={previewImgPath}
                 onChange={setPreviewImgPath}
                 onSubmit={onSubmitPreviewImgPath}
+              />
+            )
+          }
+        />
+      )}
+      {/* Only allow admin to upload logo */}
+      {previewImgPathSubmitted && isAdmin && (
+        <Step
+          status={logoPathSubmitted ? "success" : "userInput"}
+          label={
+            logoPathSubmitted
+              ? logoPath === ""
+                ? "Will not update the game logo"
+                : `Will update the logo to the one from ${logoPath}`
+              : "Provide path to game logo (optional)"
+          }
+          view={
+            !logoPathSubmitted && (
+              <TextInput
+                placeholder="/path/to/logo.png"
+                value={logoPath}
+                onChange={setLogoPath}
+                onSubmit={onSubmitLogoPath}
               />
             )
           }

--- a/packages/rune-games-cli/src/flows/Upload/CreateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Upload/CreateGameStep.tsx
@@ -20,8 +20,8 @@ export function CreateGameStep({
   const [titleSubmitted, setTitleSubmitted] = useState(false)
   const [description, setDescription] = useState("")
   const [descriptionSubmitted, setDescriptionSubmitted] = useState(false)
-  const [logoPath, setLogoPath] = useState("")
-  const [logoPathSubmitted, setLogoPathSubmitted] = useState(false)
+  const [previewImgPath, setPreviewImgPath] = useState("")
+  const [previewImgPathSubmitted, setPreviewImgPathSubmitted] = useState(false)
   const { createGame, createGameLoading, createGameError, createdGameId } =
     useCreateGame()
 
@@ -33,16 +33,18 @@ export function CreateGameStep({
     setDescriptionSubmitted(true)
   }, [])
 
-  const onSubmitLogoPath = useCallback(() => {
-    setLogoPathSubmitted(true)
+  const onSubmitPreviewImgPath = useCallback(() => {
+    setPreviewImgPathSubmitted(true)
   }, [])
 
   useEffect(() => {
-    if (titleSubmitted && descriptionSubmitted && logoPathSubmitted) {
+    if (titleSubmitted && descriptionSubmitted && previewImgPathSubmitted) {
       createGame({
         title,
         description,
-        ...(logoPath && { logo: prepareFileUpload(logoPath) }),
+        ...(previewImgPath && {
+          previewImg: prepareFileUpload(previewImgPath),
+        }),
         type: GameType.MULTIPLAYER,
       })
     }
@@ -50,8 +52,8 @@ export function CreateGameStep({
     createGame,
     description,
     descriptionSubmitted,
-    logoPath,
-    logoPathSubmitted,
+    previewImgPath,
+    previewImgPathSubmitted,
     title,
     titleSubmitted,
   ])
@@ -60,7 +62,7 @@ export function CreateGameStep({
     if (createGameError) {
       setTitleSubmitted(false)
       setDescriptionSubmitted(false)
-      setLogoPathSubmitted(false)
+      setPreviewImgPathSubmitted(false)
     }
   }, [createGameError])
 
@@ -126,21 +128,21 @@ export function CreateGameStep({
       )}
       {descriptionSubmitted && (
         <Step
-          status={logoPathSubmitted ? "success" : "userInput"}
+          status={previewImgPathSubmitted ? "success" : "userInput"}
           label={
-            logoPathSubmitted
-              ? logoPath === ""
-                ? "Will create a game without a logo"
-                : `Will use the logo at ${logoPath}`
-              : "Provide path to game logo (optional)"
+            previewImgPathSubmitted
+              ? previewImgPath === ""
+                ? "Will create a game without a preview image"
+                : `Will use the preview image at ${previewImgPath}`
+              : "Provide path to game preview image (optional)"
           }
           view={
-            !logoPathSubmitted && (
+            !previewImgPathSubmitted && (
               <TextInput
-                placeholder="/path/to/logo.png"
-                value={logoPath}
-                onChange={setLogoPath}
-                onSubmit={onSubmitLogoPath}
+                placeholder="/path/to/preview_img.png"
+                value={previewImgPath}
+                onChange={setPreviewImgPath}
+                onSubmit={onSubmitPreviewImgPath}
               />
             )
           }


### PR DESCRIPTION
Update CLI to prompt for game preview instead of logo

### Test Plan

- [x] Create new game (`rune upload`) and make sure it asks for preview img. Do not provide preview img and make sure game is created
- [x] Create new game (`rune upload`) and make sure it asks for preview img. Provide preview img and make sure game is created with preview img
- [x] Update existing game (`rune update-info`) and make sure it asks for preview img. Do not provide preview img and make sure game's preview img stays the same 
- [x] Update existing game (`rune update-info`) and make sure it asks for preview img. Provide preview img and make sure game's preview img is updated