### PR TITLE
feat(eslint): no setTimeout

### DIFF
--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -71,6 +71,8 @@ const restrictedGlobals = [
   "WeakRef",
   "Performance",
   "Intl",
+  "setInterval",
+  "setTimeout",
 ]
 
 const logicConfig: ESLint.ConfigData = {

--- a/packages/eslint-plugin-rune/src/index.ts
+++ b/packages/eslint-plugin-rune/src/index.ts
@@ -73,6 +73,8 @@ const restrictedGlobals = [
   "Intl",
   "setInterval",
   "setTimeout",
+  "require",
+  "alert",
 ]
 
 const logicConfig: ESLint.ConfigData = {

--- a/packages/eslint-plugin-rune/test/config/globals.spec.js
+++ b/packages/eslint-plugin-rune/test/config/globals.spec.js
@@ -28,7 +28,7 @@ test("globals", () => ({
   invalid: [
     ["Prune.initLogic()", "no-undef"],
     ["Object.assign(window, { hest: 'snel' })", "no-undef"],
-    ['require("hest")', "no-undef"],
+    ['require("hest")', "no-restricted-globals"],
     ["window.Math.pow()", "no-restricted-globals"],
     ["global.Math.pow()", "no-restricted-globals"],
     ["Performance.now()", "no-undef"],

--- a/packages/eslint-plugin-rune/test/config/syntax.spec.js
+++ b/packages/eslint-plugin-rune/test/config/syntax.spec.js
@@ -79,6 +79,14 @@ test("syntax", ({ type }) => ({
       "no-restricted-syntax",
     ],
     ['function* hest() { yield "snel" }', "no-restricted-syntax"],
+    [
+      'setTimeout(() => { console.log("Delayed for 1 second.") }, "1000");',
+      "no-restricted-globals",
+    ],
+    [
+      'setInterval(() => { console.log("Prints every 1 second.") }, "1000");',
+      "no-restricted-globals",
+    ],
   ].concat(
     type === "module"
       ? [

--- a/packages/eslint-plugin-rune/test/createConfigTester.js
+++ b/packages/eslint-plugin-rune/test/createConfigTester.js
@@ -42,11 +42,11 @@ const normalizeInvalidCodeTest = (test) => {
   return test
 }
 
-//Need to run tests in :
-//JS script
-//JS module
-//TS script
-//TS module
+// Need to run tests in:
+// JS script
+// JS module
+// TS script
+// TS module
 const createConfigTester = () => {
   /**
    * @param {string} testName
@@ -70,6 +70,13 @@ const createConfigTester = () => {
               language === "typescript"
                 ? "@typescript-eslint/parser"
                 : undefined,
+          },
+          // Don't use no-undef when testing as these only show up on rune upload.
+          // It's a better DX if the errors are shown while developing.
+          overrideConfig: {
+            rules: {
+              "no-undef": "off",
+            },
           },
         })
 


### PR DESCRIPTION
Realized that our eslint plugin didn't catch use of `setTimeout` so I added it as it's not allowed since Rune logic must be synchronous.