### PR TITLE
fix: use directory name if relative path

### DIFF
--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -1,7 +1,6 @@
 import fs from "fs"
 import { Box, Text } from "ink"
 import { UncontrolledTextInput } from "ink-text-input"
-import { kebabCase } from "lodash"
 import path from "path"
 import React, { useCallback, useEffect } from "react"
 import { fileURLToPath } from "url"

--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -74,7 +74,7 @@ const getPackageName = (targetDir: string) => {
   if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
 
   // Replace any non-hyphen characters (like spaces or underscores) with hyphens
-  return kebabCase(lastFolderName)
+  return lastFolderName.replace(/[^a-zA-Z0-9]/g, "-")
 }
 
 export function Create({ args }: { args: string[] }) {

--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -65,23 +65,15 @@ function emptyDir(dir: string) {
   }
 }
 
-const isRelativePath = (path: string) =>
-  path.startsWith(".") || path.startsWith("..")
-
 const getPackageName = (targetDir: string) => {
-  let packageName = targetDir
+  const fullTargetDirPath = path.resolve(targetDir)
 
-  if (isRelativePath(targetDir)) {
-    const resolvedPath = path.resolve(__dirname, targetDir)
-    const lastFolderName = resolvedPath.split(path.sep).pop()
+  const lastFolderName = fullTargetDirPath.split(path.sep).pop()
 
-    if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
-
-    packageName = lastFolderName
-  }
+  if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
 
   // Replace any non-hyphen characters (like spaces or underscores) with hyphens
-  return packageName.replace(/[^a-zA-Z0-9]/g, "-")
+  return lastFolderName.replace(/[^a-zA-Z0-9]/g, "-")
 }
 
 export function Create({ args }: { args: string[] }) {

--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -65,6 +65,21 @@ function emptyDir(dir: string) {
   }
 }
 
+const isRelativePath = (path: string) =>
+  path.startsWith(".") || path.startsWith("..")
+
+const getPackageName = (targetDir: string) => {
+  if (!isRelativePath(targetDir)) return targetDir
+
+  const resolvedPath = path.resolve(__dirname, targetDir)
+  const lastFolderName = resolvedPath.split(path.sep).pop()
+
+  if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
+
+  // Replace any non-hyphen characters (like spaces or underscores) with hyphens
+  return lastFolderName.replace(/[^a-zA-Z0-9]/g, "-")
+}
+
 export function Create({ args }: { args: string[] }) {
   const [targetDir, setTargetDir] = React.useState("")
   const [step, setStep] = React.useState(Steps.Target)
@@ -103,7 +118,7 @@ export function Create({ args }: { args: string[] }) {
       fs.readFileSync(path.join(templateDir, `package.json`), "utf-8")
     )
 
-    pkg.name = targetDir
+    pkg.name = getPackageName(targetDir)
 
     fs.writeFileSync(
       path.join(targetDir, "package.json"),

--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -69,15 +69,19 @@ const isRelativePath = (path: string) =>
   path.startsWith(".") || path.startsWith("..")
 
 const getPackageName = (targetDir: string) => {
-  if (!isRelativePath(targetDir)) return targetDir
+  let packageName = targetDir
 
-  const resolvedPath = path.resolve(__dirname, targetDir)
-  const lastFolderName = resolvedPath.split(path.sep).pop()
+  if (isRelativePath(targetDir)) {
+    const resolvedPath = path.resolve(__dirname, targetDir)
+    const lastFolderName = resolvedPath.split(path.sep).pop()
 
-  if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
+    if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
+
+    packageName = lastFolderName
+  }
 
   // Replace any non-hyphen characters (like spaces or underscores) with hyphens
-  return lastFolderName.replace(/[^a-zA-Z0-9]/g, "-")
+  return packageName.replace(/[^a-zA-Z0-9]/g, "-")
 }
 
 export function Create({ args }: { args: string[] }) {

--- a/packages/rune-games-cli/src/flows/Create.tsx
+++ b/packages/rune-games-cli/src/flows/Create.tsx
@@ -1,6 +1,7 @@
 import fs from "fs"
 import { Box, Text } from "ink"
 import { UncontrolledTextInput } from "ink-text-input"
+import { kebabCase } from "lodash"
 import path from "path"
 import React, { useCallback, useEffect } from "react"
 import { fileURLToPath } from "url"
@@ -73,7 +74,7 @@ const getPackageName = (targetDir: string) => {
   if (!lastFolderName) return "rune-game-template" // in-case they put in a root relative path
 
   // Replace any non-hyphen characters (like spaces or underscores) with hyphens
-  return lastFolderName.replace(/[^a-zA-Z0-9]/g, "-")
+  return kebabCase(lastFolderName)
 }
 
 export function Create({ args }: { args: string[] }) {


### PR DESCRIPTION
Added a fix where if they create a rune app with a relative path in their name (e.g. `.` or `..`), then it would update the package name to be the directory name associated to the relative path.