### PR TITLE
feat: Add human err msg for unexpected transparency in img

### DIFF
--- a/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Update/UpdateGameStep.tsx
@@ -195,6 +195,8 @@ export function UpdateGameStep({ gameId }: { gameId: number }) {
               ? formatApolloError(updateGameError, {
                   "Input buffer contains unsupported image format":
                     "Not an image file",
+                  "[tango][UNEXPECTED_TRANSPARENCY]":
+                    "Image should not contain transparency",
                   'value violates unique constraint "game_title_key"':
                     "Game with this title already exists",
                   default: `Something went wrong`,

--- a/packages/rune-games-cli/src/flows/Upload/CreateGameStep.tsx
+++ b/packages/rune-games-cli/src/flows/Upload/CreateGameStep.tsx
@@ -82,6 +82,8 @@ export function CreateGameStep({
               "This game title is invalid, it has to be between 5 and 25 characters, and only letters, numbers, and spaces are allowed",
             "Input buffer contains unsupported image format":
               "Not an image file",
+            "[tango][UNEXPECTED_TRANSPARENCY]":
+              "Image should not contain transparency",
             default: `Something went wrong`,
           })}
         />


### PR DESCRIPTION
Add human err msg in case uploaded game preview img contains transparent pixels.