### PR TITLE
feat: allow minification of logic.js via env variable RUNE_MINIFY_LOGIC

### DIFF
--- a/packages/vite-plugin-rune/src/terser.ts
+++ b/packages/vite-plugin-rune/src/terser.ts
@@ -48,7 +48,7 @@ export function terserPlugin(): Plugin {
         Object.keys(bundle).map(async (name) => {
           if (
             !shouldMinify ||
-            (name === "logic.js" && !process.env.RUNE_MINIFY_LOGIC)
+            (name === "logic.js" && process.env.RUNE_MINIFY_LOGIC !== "1")
           ) {
             return
           }

--- a/packages/vite-plugin-rune/src/terser.ts
+++ b/packages/vite-plugin-rune/src/terser.ts
@@ -46,7 +46,10 @@ export function terserPlugin(): Plugin {
 
       await Promise.all(
         Object.keys(bundle).map(async (name) => {
-          if (!shouldMinify || name === "logic.js") {
+          if (
+            !shouldMinify ||
+            (name === "logic.js" && !process.env.RUNE_MINIFY_LOGIC)
+          ) {
             return
           }
 


### PR DESCRIPTION
Allows using the env variable RUNE_MINIFY_LOGIC to minify `logic.js`. By default it will not be minified, setting the variable to `1` will minify the file.