### PR TITLE
build: external contributors ci checks RUNE-14649

### DIFF
--- a/scripts/copy-assets.sh
+++ b/scripts/copy-assets.sh
@@ -18,7 +18,7 @@ cd "$ASSETS_DIR" || exit 1
 
 if [ ! -e "$ASSETS_DIR/game-assets" ]
 then
-  git clone git@github.com:rune/game-assets.git
+  git clone git@github.com:rune/game-assets.git || exit 0
 else
     cd game-assets || exit 1
     git checkout -f staging

--- a/scripts/copy-assets.sh
+++ b/scripts/copy-assets.sh
@@ -18,6 +18,9 @@ cd "$ASSETS_DIR" || exit 1
 
 if [ ! -e "$ASSETS_DIR/game-assets" ]
 then
+  # If you don't have permission to checkout the assets
+  # then carry on regardless so external contributors
+  # can still pass the CI checks.
   git clone git@github.com:rune/game-assets.git || exit 0
 else
     cd game-assets || exit 1


### PR DESCRIPTION
Change the copy assets so we don't require it to pass so external contributors can pass the CI checks when they don't have access to clone the assets.
