### PR TITLE
feat: deprecate players list and add allPlayersIds to onChange

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -244,7 +244,7 @@ Opens invite modal inside the Rune app. Useful if you want to incentivize player
 
 Returns the amount of milliseconds that have passed since the start of the game. See [Using Time in your Game](advanced/real-time-games.md#game-time).
 
-### `Rune.getPlayerInfo(id)` {#dusk-get-player-info}
+### `Rune.getPlayerInfo(id)` {#rune-get-player-info}
 
 Returns information about the player with the ID specified. Note that you can pass the ID of a player no longer in game and get placeholder information.
 

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -169,6 +169,7 @@ Rune.initClient({
     futureGame,
     yourPlayerId,
     players,
+    allPlayerIds,
     action,
     event,
     rollbacks,
@@ -196,7 +197,7 @@ This argument is the predicted future game state. This value is only available i
 
 Your player id, if the current user is a spectator this argument is undefined.
 
-##### `players: Record<string, { playerId: string, displayName: string, avatarUrl: string }>` {#players-recordstring--playerid-string-displayname-string-avatarurl-string-}
+##### (Deprecated) `players: Record<string, { playerId: string, displayName: string, avatarUrl: string }>` {#players-recordstring--playerid-string-displayname-string-avatarurl-string-}
 
 The `players` argument is an object of the current players, useful to display their names and avatars in the game.
 
@@ -205,6 +206,10 @@ The `players` argument is an object of the current players, useful to display th
 Do not rely on `players` argument for determining player order, instead use `setup` and `events.playerJoined/playerLeft` callbacks in `logic.js`.
 
 :::
+
+##### `allPlayerIds?: string[]` {#all-player-ids}
+
+The player IDs of all current players in the game.
 
 ##### `action?: { name: string, playerId: string, params: any }` {#action--name-string-playerid-string-params-any-}
 
@@ -238,6 +243,10 @@ Opens invite modal inside the Rune app. Useful if you want to incentivize player
 ### `Rune.gameTime()` {#runegametime-1}
 
 Returns the amount of milliseconds that have passed since the start of the game. See [Using Time in your Game](advanced/real-time-games.md#game-time).
+
+### `Rune.getPlayerInfo(id)` {#dusk-get-player-info}
+
+Returns information about the player with the ID specified. Note that you can pass the ID of a player no longer in game and get placeholder information.
 
 ### `Rune.timeSinceLastUpdate()` {#runetimesincelastupdate}
 

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -197,7 +197,9 @@ This argument is the predicted future game state. This value is only available i
 
 Your player id, if the current user is a spectator this argument is undefined.
 
-##### (Deprecated) `players: Record<string, { playerId: string, displayName: string, avatarUrl: string }>` {#players-recordstring--playerid-string-displayname-string-avatarurl-string-}
+##### `players: Record<string, { playerId: string, displayName: string, avatarUrl: string }>` {#players-recordstring--playerid-string-displayname-string-avatarurl-string-}
+
+*Deprecated:* Use [allPlayerIds](#all-player-ids) and [Rune.getPlayerInfo](#rune-get-player-info)
 
 The `players` argument is an object of the current players, useful to display their names and avatars in the game.
 
@@ -246,7 +248,7 @@ Returns the amount of milliseconds that have passed since the start of the game.
 
 ### `Rune.getPlayerInfo(id)` {#rune-get-player-info}
 
-Returns information about the player with the ID specified. Note that you can pass the ID of a player no longer in game and get placeholder information.
+Returns information about the player with the ID specified. Note that you can pass the ID of a player that is no longer in game and get placeholder information.
 
 ### `Rune.timeSinceLastUpdate()` {#runetimesincelastupdate}
 

--- a/docs/docs/how-it-works/player-info.md
+++ b/docs/docs/how-it-works/player-info.md
@@ -6,7 +6,7 @@ sidebar_position: 20
 
 You'll often want to show each player’s name and avatar inside your game. Here's how you do it.
 
-## Players Object {#players-object}
+## (Deprecated) Players Object {#players-object}
 
 Info about the players is captured by a `players` object, which has an ID for each player as the key and an object with e.g. `displayName` as the value. These IDs are unique and randomly generated for each game. The players are organized in the players object in no particular order.
 
@@ -15,7 +15,19 @@ Here’s the values for each player:
 - `displayName: string`
 - `avatarUrl: string`
 - `playerId: string` (same as key, just provided for simplicity)
+  
+## Players in Game {#players-in-game}
 
+The list of IDs of players who are active in the game is provided in the `OnChange` callback through the `allPlayerIds` array. This list contains all players who are playing and are still connected to the room.
+
+## Getting Player Info {#getting-player-info}
+
+The `Rune.getPlayerInfo(id)` function is used to retrieve information about a player. The return player object contains the following values:
+
+- `displayName: string`
+- `avatarUrl: string`
+- `playerId: string` (same as key, just provided for simplicity)
+  
 ## Avatars {#avatars}
 
 Using avatars is a great way to personalize the UI to show whose turn it is or in a leaderboard. Since the avatar is loaded over the network there might be a slight delay during which you might want to display a placeholder – and we got you covered!

--- a/docs/docs/how-it-works/player-info.md
+++ b/docs/docs/how-it-works/player-info.md
@@ -6,7 +6,9 @@ sidebar_position: 20
 
 You'll often want to show each player’s name and avatar inside your game. Here's how you do it.
 
-## (Deprecated) Players Object {#players-object}
+## Players Object {#players-object}
+
+*Deprecated:* Use [allPlayerIds](api-reference.md#all-player-ids) and [Rune.getPlayerInfo](api-reference.md#rune-get-player-info)
 
 Info about the players is captured by a `players` object, which has an ID for each player as the key and an object with e.g. `displayName` as the value. These IDs are unique and randomly generated for each game. The players are organized in the players object in no particular order.
 
@@ -22,12 +24,14 @@ The list of IDs of players who are active in the game is provided in the `OnChan
 
 ## Getting Player Info {#getting-player-info}
 
-The `Rune.getPlayerInfo(id)` function is used to retrieve information about a player. The return player object contains the following values:
+The `Rune.getPlayerInfo(id)` function is used to retrieve information about a player. The returned object contains the following values:
 
 - `displayName: string`
 - `avatarUrl: string`
 - `playerId: string` (same as key, just provided for simplicity)
-  
+
+Note that you can pass the ID of a player that is no longer in game and get placeholder information.
+
 ## Avatars {#avatars}
 
 Using avatars is a great way to personalize the UI to show whose turn it is or in a leaderboard. Since the avatar is loaded over the network there might be a slight delay during which you might want to display a placeholder – and we got you covered!


### PR DESCRIPTION
Deprecate the use of players list in the onChange callback.

Add allPlayerIds to the onChange callback to include the list of connected players.

Add Rune.getPlayerInfo(id) to get player information (display name / avatar) that supports placeholder information for players that have left.
