### PR TITLE
fix: paddle game added missing logic script

### DIFF
--- a/examples/paddle/index.html
+++ b/examples/paddle/index.html
@@ -30,6 +30,7 @@
   <link rel="preload" href="fonts/Poppins-ExtraBold.ttf" as="font" crossorigin="anonymous" />
 </head>
 <body>
+<script type="module" src="/src/logic.ts"></script>
 <script type="module" src="/src/client.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
Paddle game index html was missing logic script, so it did not work in devui.