### PR TITLE
fix: game file zipping issues in CLI

### DIFF
--- a/packages/dusk-cli/src/lib/validateGameFiles.ts
+++ b/packages/dusk-cli/src/lib/validateGameFiles.ts
@@ -81,6 +81,8 @@ export async function validateGameFilesWithEval(
   const gameConfig = logicJs
     ? eval(
         `
+          //Prevent Math precision from being modified
+          globalThis.Math.__SDK_PRECISION_SET__ = true
           ${logicRunner}
           ${logicJs!.content}
           Rune.gameConfig

--- a/packages/rune-games-cli/src/lib/validateGameFiles.ts
+++ b/packages/rune-games-cli/src/lib/validateGameFiles.ts
@@ -81,6 +81,8 @@ export async function validateGameFilesWithEval(
   const gameConfig = logicJs
     ? eval(
         `
+          //Prevent Math precision from being modified
+          globalThis.Math.__SDK_PRECISION_SET__ = true
           ${logicRunner}
           ${logicJs!.content}
           Rune.gameConfig


### PR DESCRIPTION
Prevents logic runner from modifying the math precision which breaks zipping.