### PR TITLE
fix: use beta eslint-plugin-react-hooks package

### DIFF
--- a/examples/neon-snake/package.json
+++ b/examples/neon-snake/package.json
@@ -29,7 +29,7 @@
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/examples/neon-snake/yarn.lock
+++ b/examples/neon-snake/yarn.lock
@@ -2225,10 +2225,10 @@ eslint-plugin-prettier@^5.2.1:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.9.1"
 
-eslint-plugin-react-hooks@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@beta:
+  version "5.1.0-beta-26f2496093-20240514"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
+  integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
 eslint-plugin-react-refresh@^0.4.9:
   version "0.4.9"

--- a/examples/oink-oink/package.json
+++ b/examples/oink-oink/package.json
@@ -27,7 +27,7 @@
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/examples/oink-oink/yarn.lock
+++ b/examples/oink-oink/yarn.lock
@@ -4312,10 +4312,10 @@ eslint-plugin-react-hooks@^4.3.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react-hooks@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@beta:
+  version "5.1.0-beta-26f2496093-20240514"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
+  integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
 eslint-plugin-react-refresh@^0.4.9:
   version "0.4.9"

--- a/examples/pinpoint/package.json
+++ b/examples/pinpoint/package.json
@@ -29,7 +29,7 @@
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/examples/pinpoint/yarn.lock
+++ b/examples/pinpoint/yarn.lock
@@ -4549,10 +4549,10 @@ eslint-plugin-react-hooks@^4.3.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react-hooks@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@beta:
+  version "5.1.0-beta-26f2496093-20240514"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
+  integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
 eslint-plugin-react-refresh@^0.4.9:
   version "0.4.9"

--- a/examples/sudoku/package.json
+++ b/examples/sudoku/package.json
@@ -29,7 +29,7 @@
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "prettier": "^3.3.3",
     "globals": "^15.8.0",

--- a/examples/sudoku/yarn.lock
+++ b/examples/sudoku/yarn.lock
@@ -4320,10 +4320,10 @@ eslint-plugin-react-hooks@^4.3.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react-hooks@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@beta:
+  version "5.1.0-beta-26f2496093-20240514"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
+  integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
 eslint-plugin-react-refresh@^0.4.9:
   version "0.4.9"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "husky": "7.0.2",

--- a/packages/dusk-cli/templates/javascript-react/package.json
+++ b/packages/dusk-cli/templates/javascript-react/package.json
@@ -22,7 +22,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/packages/dusk-cli/templates/typescript-pixi-react/package.json
+++ b/packages/dusk-cli/templates/typescript-pixi-react/package.json
@@ -27,7 +27,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/packages/dusk-cli/templates/typescript-react/package.json
+++ b/packages/dusk-cli/templates/typescript-react/package.json
@@ -25,7 +25,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",

--- a/packages/vite-plugin-dusk/playground/package.json
+++ b/packages/vite-plugin-dusk/playground/package.json
@@ -22,7 +22,7 @@
     "@typescript-eslint/parser": "^5.57.1",
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "7.22.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "beta",
     "eslint-plugin-react-refresh": "^0.3.4",
     "eslint-plugin-dusk": "^0.2.0",
     "typescript": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,10 +6887,10 @@ eslint-plugin-prettier@^5.2.1:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.9.1"
 
-eslint-plugin-react-hooks@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@beta:
+  version "5.1.0-beta-26f2496093-20240514"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
+  integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
 eslint-plugin-react-refresh@^0.4.9:
   version "0.4.9"


### PR DESCRIPTION
To fix issues with npm peer dependencies, we need to use beta until https://github.com/facebook/react/issues/28313 is resolved.