### PR TITLE
fix: remove refresh plugin

### DIFF
--- a/examples/neon-snake/eslint.config.mjs
+++ b/examples/neon-snake/eslint.config.mjs
@@ -3,7 +3,6 @@ import globals from "globals"
 import duskPlugin from "dusk-games-sdk/eslint.js"
 import tseslint from "typescript-eslint"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import { fixupPluginRules } from "@eslint/compat"
 import prettier from "eslint-plugin-prettier/recommended"
 
@@ -17,9 +16,6 @@ export default [
       ecmaVersion: "latest",
       sourceType: "module",
     },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
-    },
   },
   js.configs.recommended,
   ...duskPlugin.configs.recommended,
@@ -29,11 +25,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/examples/neon-snake/package.json
+++ b/examples/neon-snake/package.json
@@ -30,7 +30,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "typescript": "^5.0.2",

--- a/examples/neon-snake/yarn.lock
+++ b/examples/neon-snake/yarn.lock
@@ -2230,11 +2230,6 @@ eslint-plugin-react-hooks@beta:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
   integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
-eslint-plugin-react-refresh@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz#bf870372b353b12e1e6fb7fc41b282d9cbc8d93d"
-  integrity sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==
-
 eslint-scope@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.0.2.tgz#5cbb33d4384c9136083a71190d548158fe128f94"

--- a/examples/oink-oink/eslint.config.mjs
+++ b/examples/oink-oink/eslint.config.mjs
@@ -3,7 +3,6 @@ import globals from "globals"
 import duskPlugin from "dusk-games-sdk/eslint.js"
 import tseslint from "typescript-eslint"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import { fixupPluginRules } from "@eslint/compat"
 import prettier from "eslint-plugin-prettier/recommended"
 
@@ -17,9 +16,6 @@ export default [
       ecmaVersion: "latest",
       sourceType: "module",
     },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
-    },
   },
   js.configs.recommended,
   ...duskPlugin.configs.recommended,
@@ -29,11 +25,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/examples/oink-oink/package.json
+++ b/examples/oink-oink/package.json
@@ -28,7 +28,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "react-scripts": "5.0.1",

--- a/examples/oink-oink/yarn.lock
+++ b/examples/oink-oink/yarn.lock
@@ -4317,11 +4317,6 @@ eslint-plugin-react-hooks@beta:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
   integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
-eslint-plugin-react-refresh@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz#bf870372b353b12e1e6fb7fc41b282d9cbc8d93d"
-  integrity sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==
-
 eslint-plugin-react@^7.27.1:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"

--- a/examples/pinpoint/eslint.config.mjs
+++ b/examples/pinpoint/eslint.config.mjs
@@ -3,7 +3,6 @@ import globals from "globals"
 import duskPlugin from "dusk-games-sdk/eslint.js"
 import tseslint from "typescript-eslint"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import { fixupPluginRules } from "@eslint/compat"
 import prettier from "eslint-plugin-prettier/recommended"
 
@@ -17,9 +16,6 @@ export default [
       ecmaVersion: "latest",
       sourceType: "module",
     },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
-    },
   },
   js.configs.recommended,
   ...duskPlugin.configs.recommended,
@@ -32,7 +28,6 @@ export default [
   },
   {
     rules: {
-      "react-refresh/only-export-components": "warn",
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/no-explicit-any": "off",
     },

--- a/examples/pinpoint/package.json
+++ b/examples/pinpoint/package.json
@@ -30,7 +30,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "react-scripts": "5.0.1",

--- a/examples/pinpoint/yarn.lock
+++ b/examples/pinpoint/yarn.lock
@@ -4554,11 +4554,6 @@ eslint-plugin-react-hooks@beta:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
   integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
-eslint-plugin-react-refresh@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz#bf870372b353b12e1e6fb7fc41b282d9cbc8d93d"
-  integrity sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==
-
 eslint-plugin-react@^7.27.1:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"

--- a/examples/sudoku/eslint.config.mjs
+++ b/examples/sudoku/eslint.config.mjs
@@ -3,7 +3,6 @@ import globals from "globals"
 import duskPlugin from "dusk-games-sdk/eslint.js"
 import tseslint from "typescript-eslint"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import { fixupPluginRules } from "@eslint/compat"
 import prettier from "eslint-plugin-prettier/recommended"
 
@@ -17,9 +16,6 @@ export default [
       ecmaVersion: "latest",
       sourceType: "module",
     },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
-    },
   },
   js.configs.recommended,
   ...duskPlugin.configs.recommended,
@@ -29,11 +25,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/examples/sudoku/package.json
+++ b/examples/sudoku/package.json
@@ -30,7 +30,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "prettier": "^3.3.3",
     "globals": "^15.8.0",
     "react-scripts": "5.0.1",

--- a/examples/sudoku/yarn.lock
+++ b/examples/sudoku/yarn.lock
@@ -4325,11 +4325,6 @@ eslint-plugin-react-hooks@beta:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
   integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
-eslint-plugin-react-refresh@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz#bf870372b353b12e1e6fb7fc41b282d9cbc8d93d"
-  integrity sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==
-
 eslint-plugin-react@^7.27.1:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "husky": "7.0.2",
     "lerna": "^6.1.0",

--- a/packages/dusk-cli/templates/javascript-react/eslint.config.mjs
+++ b/packages/dusk-cli/templates/javascript-react/eslint.config.mjs
@@ -4,7 +4,6 @@ import duskPlugin from "dusk-games-sdk/eslint.js"
 import prettier from "eslint-plugin-prettier/recommended"
 import pluginReact from "eslint-plugin-react"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import globals from "globals"
 
 export default [
@@ -16,9 +15,6 @@ export default [
       },
       ecmaVersion: "latest",
       sourceType: "module",
-    },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
     },
     settings: {
       react: {
@@ -35,11 +31,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/packages/dusk-cli/templates/javascript-react/package.json
+++ b/packages/dusk-cli/templates/javascript-react/package.json
@@ -23,7 +23,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "vite": "^5.2.11",

--- a/packages/dusk-cli/templates/typescript-pixi-react/eslint.config.mjs
+++ b/packages/dusk-cli/templates/typescript-pixi-react/eslint.config.mjs
@@ -4,7 +4,6 @@ import duskPlugin from "dusk-games-sdk/eslint.js"
 import prettier from "eslint-plugin-prettier/recommended"
 import pluginReact from "eslint-plugin-react"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import globals from "globals"
 import tseslint from "typescript-eslint"
 
@@ -17,9 +16,6 @@ export default [
       },
       ecmaVersion: "latest",
       sourceType: "module",
-    },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
     },
     settings: {
       react: {
@@ -37,11 +33,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/packages/dusk-cli/templates/typescript-pixi-react/package.json
+++ b/packages/dusk-cli/templates/typescript-pixi-react/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "typescript": "^5.4.5",

--- a/packages/dusk-cli/templates/typescript-react/eslint.config.mjs
+++ b/packages/dusk-cli/templates/typescript-react/eslint.config.mjs
@@ -4,7 +4,6 @@ import duskPlugin from "dusk-games-sdk/eslint.js"
 import prettier from "eslint-plugin-prettier/recommended"
 import pluginReact from "eslint-plugin-react"
 import pluginReactHooks from "eslint-plugin-react-hooks"
-import pluginReactRefresh from "eslint-plugin-react-refresh"
 import globals from "globals"
 import tseslint from "typescript-eslint"
 
@@ -17,9 +16,6 @@ export default [
       },
       ecmaVersion: "latest",
       sourceType: "module",
-    },
-    plugins: {
-      "react-refresh": pluginReactRefresh,
     },
     settings: {
       react: {
@@ -37,11 +33,6 @@ export default [
       "react-hooks": fixupPluginRules(pluginReactHooks),
     },
     rules: pluginReactHooks.configs.recommended.rules,
-  },
-  {
-    rules: {
-      "react-refresh/only-export-components": "warn",
-    },
   },
   prettier,
 ]

--- a/packages/dusk-cli/templates/typescript-react/package.json
+++ b/packages/dusk-cli/templates/typescript-react/package.json
@@ -26,7 +26,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.8.0",
     "prettier": "^3.3.3",
     "typescript": "^5.4.5",

--- a/packages/vite-plugin-dusk/playground/package.json
+++ b/packages/vite-plugin-dusk/playground/package.json
@@ -23,7 +23,6 @@
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "7.22.0",
     "eslint-plugin-react-hooks": "beta",
-    "eslint-plugin-react-refresh": "^0.3.4",
     "eslint-plugin-dusk": "^0.2.0",
     "typescript": "^5.0.2",
     "vite": "5.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6892,11 +6892,6 @@ eslint-plugin-react-hooks@beta:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-beta-26f2496093-20240514.tgz#ca1309b80d07927d00d8b503832796baf620df9a"
   integrity sha512-nCZD93/KYY5hNAWGhfvvrEXvLFIXJCMu2St7ciHeiWUp/lnS2RVgWawp2kNQamr9Y23C9lUA03TmDRNgbm05vg==
 
-eslint-plugin-react-refresh@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz#bf870372b353b12e1e6fb7fc41b282d9cbc8d93d"
-  integrity sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==
-
 eslint-plugin-react@^7.35.0:
   version "7.35.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz#00b1e4559896710e58af6358898f2ff917ea4c41"


### PR DESCRIPTION
It does not support eslint 9 (so npm install will also fail).
Its not really benefitial for dusk users (we reload devui in any case when any change is detected).
