### PR TITLE
build: relax eslint rules for ts-ignore

### DIFF
--- a/packages/rune/templates/typescript-pixi-react/eslint.config.mjs
+++ b/packages/rune/templates/typescript-pixi-react/eslint.config.mjs
@@ -37,6 +37,8 @@ export default [
   {
     rules: {
       "prettier/prettier": "warn",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ]

--- a/packages/rune/templates/typescript-react/eslint.config.mjs
+++ b/packages/rune/templates/typescript-react/eslint.config.mjs
@@ -37,6 +37,8 @@ export default [
   {
     rules: {
       "prettier/prettier": "warn",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ]

--- a/packages/rune/templates/typescript-svelte/eslint.config.mjs
+++ b/packages/rune/templates/typescript-svelte/eslint.config.mjs
@@ -42,6 +42,8 @@ export default [
   {
     rules: {
       "prettier/prettier": "warn",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ]

--- a/packages/rune/templates/typescript-vue/eslint.config.mjs
+++ b/packages/rune/templates/typescript-vue/eslint.config.mjs
@@ -24,6 +24,8 @@ export default [
   {
     rules: {
       "prettier/prettier": "warn",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
   {

--- a/packages/rune/templates/typescript/eslint.config.mjs
+++ b/packages/rune/templates/typescript/eslint.config.mjs
@@ -22,6 +22,8 @@ export default [
   {
     rules: {
       "prettier/prettier": "warn",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ]


### PR DESCRIPTION
Relax a few of the linting rules per RUNE-18661

- Allow the use of ts-ignore
- Use of any now only a warning