### PR TITLE
refactor: streamline error handling in checkProjectErrorsTool and upd…

### DIFF
--- a/packages/rune-mcp/package.json
+++ b/packages/rune-mcp/package.json
@@ -48,7 +48,6 @@
   "files": [
     "bin",
     "dist",
-    "templates",
     "prompts",
     "LICENSE",
     "README.md"

--- a/packages/rune-mcp/src/text/checkProjectErrorsText.ts
+++ b/packages/rune-mcp/src/text/checkProjectErrorsText.ts
@@ -10,31 +10,14 @@ Common use cases:
 - When the user is preparing to commit or deploy their code
 - When the user is experiencing unexpected behavior that might be due to type errors`
 
-export const checkProjectErrorsTypecheckStarted =
-  "Running TypeScript type checker on your project..."
+export type CheckErrorsOutput = {
+  type: "typescript" | "eslint"
+  output: string
+}
 
-export const checkProjectErrorsLintStarted =
-  "No TypeScript errors found. Running ESLint on your project..."
-
-export const checkProjectErrorsTypecheckFailed = (errors: string) =>
-  `TypeScript errors found in your project:
-
-\`\`\`
-${errors}
-\`\`\`
-
-Please fix the TypeScript errors above before proceeding.`
-
-export const checkProjectErrorsLintFailed = (errors: string) =>
-  `ESLint errors found in your project:
-
-\`\`\`
-${errors}
-\`\`\`
-
-Please fix the ESLint errors above.
-Rune projects enforce custom ESLint rules to make sure the code will interact correctly with the Rune SDK
-so it is important to fix these errors before proceeding.`
+export const checkProjectErrorsFound = (errors: CheckErrorsOutput[]) =>
+  errors.map((error) => `${error.type} errors:\n${error.output}\n`).join("") +
+  "Fix the errors and try again."
 
 export const checkProjectErrorsNoneFound = `Great news! No TypeScript or ESLint errors were found in your project.
 

--- a/packages/rune-mcp/src/tools/checkProjectErrorsTool.ts
+++ b/packages/rune-mcp/src/tools/checkProjectErrorsTool.ts
@@ -6,13 +6,11 @@ import fs from "fs"
 import path from "path"
 import {
   checkProjectErrorsToolDescription,
-  checkProjectErrorsTypecheckStarted,
-  checkProjectErrorsLintStarted,
-  checkProjectErrorsTypecheckFailed,
-  checkProjectErrorsLintFailed,
+  checkProjectErrorsFound,
   checkProjectErrorsNoneFound,
   checkProjectErrorsScriptNotFound,
   projectPathParameterDescription,
+  CheckErrorsOutput,
 } from "../text/checkProjectErrorsText.js"
 import { logError } from "../services/logging.js"
 
@@ -82,6 +80,9 @@ export const checkProjectErrorsTool = (server: McpServer): void => {
       }
 
       try {
+        // Track errors from both commands
+        const errors: Array<CheckErrorsOutput> = []
+
         // First check if typecheck script exists
         const typecheckExists = scriptExists(packageJsonPath, "typecheck")
         if (!typecheckExists) {
@@ -100,17 +101,35 @@ export const checkProjectErrorsTool = (server: McpServer): void => {
           }
         }
 
+        // Now check if lint script exists
+        const lintExists = scriptExists(packageJsonPath, "lint")
+        if (!lintExists) {
+          server.server.sendLoggingMessage({
+            level: "error",
+            data: "Lint script not found in package.json",
+          })
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: checkProjectErrorsScriptNotFound("lint"),
+              },
+            ],
+          }
+        }
+
+        // Change to the project directory for all commands
+        process.chdir(projectPath)
+
         // Run the typecheck command
         server.server.sendLoggingMessage({
           level: "info",
-          data: checkProjectErrorsTypecheckStarted,
+          data: "TypeScript check started",
         })
 
-        let typecheckResult
         try {
-          // Change to the project directory and run the typecheck
-          process.chdir(projectPath)
-          typecheckResult = await execPromise("npm run typecheck", {
+          const typecheckResult = await execPromise("npm run typecheck", {
             timeout: 60000,
           })
 
@@ -119,69 +138,6 @@ export const checkProjectErrorsTool = (server: McpServer): void => {
             level: "info",
             data: `TypeScript check passed ${typecheckResult.stdout}`,
           })
-
-          // Now check if lint script exists
-          const lintExists = scriptExists(packageJsonPath, "lint")
-          if (!lintExists) {
-            server.server.sendLoggingMessage({
-              level: "error",
-              data: "Lint script not found in package.json",
-            })
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: checkProjectErrorsScriptNotFound("lint"),
-                },
-              ],
-            }
-          }
-
-          // Run the lint command
-          server.server.sendLoggingMessage({
-            level: "info",
-            data: checkProjectErrorsLintStarted,
-          })
-
-          try {
-            const lintResult = await execPromise("npm run lint -- --fix", {
-              timeout: 60000,
-            })
-
-            // If we get here, lint passed with no errors
-            server.server.sendLoggingMessage({
-              level: "info",
-              data: `ESLint check passed ${lintResult.stdout}`,
-            })
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: checkProjectErrorsNoneFound,
-                },
-              ],
-            }
-          } catch (lintError) {
-            // Lint found errors
-
-            const errorOutput = getErrorOutput(lintError)
-
-            server.server.sendLoggingMessage({
-              level: "error",
-              data: `ESLint errors: ${errorOutput}`,
-            })
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: checkProjectErrorsLintFailed(errorOutput),
-                },
-              ],
-            }
-          }
         } catch (typecheckError) {
           // Typecheck found errors
           const errorOutput = getErrorOutput(typecheckError)
@@ -191,11 +147,55 @@ export const checkProjectErrorsTool = (server: McpServer): void => {
             data: `TypeScript errors: ${errorOutput}`,
           })
 
+          errors.push({ type: "typescript", output: errorOutput })
+        }
+
+        // Run the lint command
+        server.server.sendLoggingMessage({
+          level: "info",
+          data: "ESLint check started",
+        })
+
+        try {
+          const lintResult = await execPromise("npm run lint -- --fix", {
+            timeout: 60000,
+          })
+
+          // If we get here, lint passed with no errors
+          server.server.sendLoggingMessage({
+            level: "info",
+            data: `ESLint check passed ${lintResult.stdout}`,
+          })
+        } catch (lintError) {
+          // Lint found errors
+          const errorOutput = getErrorOutput(lintError)
+
+          server.server.sendLoggingMessage({
+            level: "error",
+            data: `ESLint errors: ${errorOutput}`,
+          })
+
+          errors.push({ type: "eslint", output: errorOutput })
+        }
+
+        // Return appropriate response based on the collected errors
+        if (errors.length === 0) {
           return {
             content: [
               {
                 type: "text",
-                text: checkProjectErrorsTypecheckFailed(errorOutput),
+                text: checkProjectErrorsNoneFound,
+              },
+            ],
+          }
+        } else {
+          // Generate response with all errors
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: checkProjectErrorsFound(errors),
               },
             ],
           }


### PR DESCRIPTION
Instead of failing fast, the check-project-errors tool now checks for typescript errors then eslint errors and returns all the errors found.
