### PR TITLE
Incrementing vite-plugin-rune package version for release

### DIFF
--- a/packages/vite-plugin-rune/package.json
+++ b/packages/vite-plugin-rune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-rune",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Vite plugin for Rune SDK",
   "license": "MIT",


### PR DESCRIPTION
Bumps `vite-plugin-rune` 1.1.0 → 1.1.1 so the rune-sdk layout fix from #657 can be released.

`lerna publish from-package` only publishes packages whose version is ahead of npm, and every package currently matches what's published, so the release workflow is a no-op until this lands.

Patch bump — #657 is a bugfix, no API change.

After merging: Actions → **Release NPM packages** → Run workflow on `staging`.

Note that forge's `packages/rune-sdk/vite/` is a checked-in copy of this plugin's `dist` and carries the same bug. Publishing here doesn't update it; it needs its own PR.
