### PR TITLE
build(ci): publish to npm via oidc trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,19 @@
 name: Release NPM packages
 
+# Publishes any package under packages/ whose version is not yet on npm.
+#
+# Authenticates to npm over GitHub OIDC (trusted publishing), so no npm
+# credential is stored in this repo. npm's trusted publisher config is keyed on
+# the repo AND this workflow's filename — renaming release.yml breaks publishing
+# until the config is updated at npmjs.com, and each package needs its own entry
+# (a package can only have one trusted publisher at a time).
+
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   npm:
@@ -17,19 +26,16 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Not .node-version (v20): trusted publishing needs Node >= 22.14.0 and npm
+      # >= 11.5.1. Node 24 is the first line that clears both out of the box —
+      # every 22.x ships npm 10.x, which has no OIDC support at all. Only this
+      # job is pinned forward; the rest of CI stays on v20, where docusaurus
+      # still builds.
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".node-version"
+          node-version: "24"
           cache: "yarn"
-
-      - name: Git Identity
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install npm dependencies
         run: yarn --prefer-offline --frozen-lockfile --non-interactive --ignore-scripts --silent
@@ -37,10 +43,35 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Publish to NPM
+      # Replaces `lerna publish from-package`, which publishes through its
+      # bundled libnpmpublish and never performs the OIDC exchange — only the npm
+      # CLI does. Same selection rule: publish a package when its version is not
+      # already on the registry, skip it otherwise.
+      - name: Publish changed packages to NPM
         run: |
-          echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > .npmrc
-          yarn lerna publish from-package --yes
-          rm .npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          set -euo pipefail
+          published=0
+          for dir in packages/*/; do
+            [ -f "$dir/package.json" ] || continue
+
+            name=$(jq -r '.name' "$dir/package.json")
+            version=$(jq -r '.version' "$dir/package.json")
+
+            if [ "$(jq -r '.private // false' "$dir/package.json")" = "true" ]; then
+              echo "skip $name (private)"
+              continue
+            fi
+
+            if [ -n "$(npm view "$name@$version" version 2>/dev/null || true)" ]; then
+              echo "skip $name@$version (already on npm)"
+              continue
+            fi
+
+            echo "publishing $name@$version"
+            (cd "$dir" && npm publish)
+            published=$((published + 1))
+          done
+
+          if [ "$published" -eq 0 ]; then
+            echo "Nothing to publish — every package matches the registry."
+          fi


### PR DESCRIPTION
## Problem

The release workflow authenticates with a long-lived `NPM_TOKEN`. It's been failing since the fix in #657 was ready to ship:

- run [`31008339802`](https://github.com/rune/rune/actions/runs/31008339802) — `E404 Not found`, the registry rejecting a credential it no longer recognises (the token was last used 2025-11-03).
- run [`31009537722`](https://github.com/rune/rune/actions/runs/31009537722), after a fresh token — `E403 You may not perform that action with these credentials`.

Token publishing is a shrinking path anyway. Per [about-access-tokens](https://docs.npmjs.com/about-access-tokens): *"As of November 2025, only Granular access tokens are supported. Legacy access tokens have been removed."* — and the same page: *"For CI/CD publishing, consider adopting trusted publishing instead."*

Same swap forge made for `rune-sdk` in rune/forge#1126.

## Why lerna had to go

`lerna publish from-package` publishes through its bundled `libnpmpublish` — there are no OIDC references anywhere in `node_modules/lerna/dist`. The OIDC exchange lives only in the npm CLI ([`lib/commands/publish.js`](https://github.com/npm/cli/blob/v11.5.1/lib/commands/publish.js)), so lerna would attempt an unauthenticated publish and fail exactly as it does now.

The loop that replaces it keeps lerna's `from-package` rule verbatim: publish a package when its version isn't on the registry, skip it otherwise, skip `private`.

## What changed

- `id-token: write` on the job — [trusted-publishers](https://docs.npmjs.com/trusted-publishers): *"The critical requirement is the `id-token: write` permission"*. `contents` drops to `read`.
- `node-version: "24"` on this job only. Trusted publishing needs Node >= 22.14.0 **and npm >= 11.5.1**, and 24 is the first line clearing both without extra steps — every 22.x ships npm 10.x, which has no OIDC support:

  | Node | bundled npm | clears 11.5.1 |
  | --- | --- | --- |
  | 22.23.2 (latest 22) | 10.9.8 | no |
  | 24.19.0 (latest 24) | 11.17.0 | yes |

  `.node-version` stays v20 — docusaurus fails SSR above it — so only this job moves.
- The `.npmrc` write, `NODE_AUTH_TOKEN`, and `rm .npmrc` are gone. So is the git identity step, which existed for lerna.

## Before this can publish

npm's trusted publisher has to be configured at npmjs.com by the package owner (currently `sanjaypojo` on all four packages): **`rune/rune`** → **`release.yml`**.

Two things to know:

- It's keyed on the **workflow filename**. Renaming `release.yml` breaks publishing until the config is updated.
- *"Each package can only have one trusted publisher configured at a time"* — so it's one entry per package. `vite-plugin-rune` is the only one that needs it now; the others can be added when they next release.

`NPM_TOKEN` can be deleted from repo secrets once a publish succeeds.

## Verification

Not dispatched yet — it can't succeed until the npm-side config above exists.

- YAML parses; `bash -n` passes on every shell block; `yarn build` verified on node 24 locally.
- The selection loop, run against this repo as-is, picks exactly what lerna picked in run `31008339802` ("Found 1 package to publish: vite-plugin-rune => 1.1.1"):

```
skip eslint-plugin-rune@2.1.0 (already on npm)
skip rune-interpolators (private)
skip rune-mcp@0.1.0 (already on npm)
skip rune@8.0.3 (already on npm)
WOULD PUBLISH vite-plugin-rune@1.1.1
```

Since `rune/rune` is public, npm will also attach provenance automatically — forge doesn't get this, as the CLI gates it on repository visibility.
